### PR TITLE
Stabilize canonical game serialization

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Kriegspiel v. 1.2.3
+
+- **Canonical Engine State**: `BerkeleyGame` serialization now stores `possible_to_ask`, so active turns can be resumed without losing question-state
+- **Stable Schema Versioning**: serialization compatibility now uses a dedicated `schema_version` instead of tying saved payloads to the package version
+- **Safety**: canonical payloads still validate `move_stack` against `board_fen` and scoresheet-derived moves before loading
+
 ## Kriegspiel v. 1.2.2
 
 - **README Refresh**: simplified the package overview and trimmed maintainer-focused setup details from the published project description

--- a/kriegspiel/__init__.py
+++ b/kriegspiel/__init__.py
@@ -4,4 +4,4 @@ __author__ = "Alexander Filatov"
 
 __email__ = "alexander@kriegspiel.org"
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"

--- a/kriegspiel/serialization.py
+++ b/kriegspiel/serialization.py
@@ -8,14 +8,16 @@ Kriegspiel game components using JSON format with custom encoders/decoders.
 
 JSON Schema Structure:
 {
-  "version": "1.2.1",
+  "schema_version": 3,
+  "library_version": "1.2.3",
   "game_type": "BerkeleyGame",
   "game_state": {
     "any_rule": bool,
     "board_fen": str,
     "move_stack": [str],  // UCI moves used to verify board reconstruction
-    "must_use_pawns": bool, 
+    "must_use_pawns": bool,
     "game_over": bool,
+    "possible_to_ask": [...],  // Serialized KriegspielMove values for exact turn-state recovery
     "white_scoresheet": {
       "color": "WHITE",
       "moves_own": [...],
@@ -23,7 +25,7 @@ JSON Schema Structure:
       "last_move_number": int
     },
     "black_scoresheet": {
-      "color": "BLACK", 
+      "color": "BLACK",
       "moves_own": [...],
       "moves_opponent": [...],
       "last_move_number": int
@@ -63,8 +65,8 @@ from kriegspiel.move import (
 # Import version from main module
 from kriegspiel import __version__
 
-# Current serialization format version matches module version
-SERIALIZATION_VERSION = __version__
+LEGACY_SERIALIZATION_SCHEMA_VERSION = 2
+SERIALIZATION_SCHEMA_VERSION = 3
 
 
 class SerializationError(Exception):
@@ -165,6 +167,20 @@ def deserialize_kriegspiel_move(data: Dict[str, Any]) -> KriegspielMove:
         raise MalformedDataError(f"Invalid KriegspielMove data: {data}") from e
 
 
+def serialize_possible_to_ask(moves: List[KriegspielMove]) -> List[Dict[str, Any]]:
+    """Serialize current turn-state questions in a stable order."""
+    serialized = [serialize_kriegspiel_move(move) for move in moves]
+    serialized.sort(key=lambda item: (item["question_type"], item["chess_move"] or ""))
+    return serialized
+
+
+def deserialize_possible_to_ask(data: Any) -> List[KriegspielMove]:
+    """Deserialize serialized possible_to_ask entries."""
+    if not isinstance(data, list):
+        raise MalformedDataError("Invalid possible_to_ask: expected a list of KriegspielMove values")
+    return [deserialize_kriegspiel_move(item) for item in data]
+
+
 def serialize_kriegspiel_answer(answer: KriegspielAnswer) -> Dict[str, Any]:
     """Serialize KriegspielAnswer to dictionary."""
     return {
@@ -250,7 +266,8 @@ def deserialize_kriegspiel_scoresheet(data: Dict[str, Any]) -> KriegspielScoresh
 def serialize_berkeley_game(game) -> Dict[str, Any]:
     """Serialize BerkeleyGame to dictionary."""
     return {
-        "version": SERIALIZATION_VERSION,
+        "schema_version": SERIALIZATION_SCHEMA_VERSION,
+        "library_version": __version__,
         "game_type": "BerkeleyGame",
         "game_state": {
             "any_rule": game._any_rule,
@@ -258,6 +275,7 @@ def serialize_berkeley_game(game) -> Dict[str, Any]:
             "move_stack": [move.uci() for move in game._board.move_stack],
             "must_use_pawns": game._must_use_pawns,
             "game_over": game._game_over,
+            "possible_to_ask": serialize_possible_to_ask(game.possible_to_ask),
             "white_scoresheet": serialize_kriegspiel_scoresheet(game._whites_scoresheet),
             "black_scoresheet": serialize_kriegspiel_scoresheet(game._blacks_scoresheet)
         }
@@ -267,10 +285,12 @@ def serialize_berkeley_game(game) -> Dict[str, Any]:
 def deserialize_berkeley_game(data: Dict[str, Any]):
     """Deserialize dictionary to BerkeleyGame."""
     try:
-        # Check version compatibility
-        version = data.get("version", "unknown")
-        if version != SERIALIZATION_VERSION:
-            raise UnsupportedVersionError(f"Unsupported version: {version}. Expected: {SERIALIZATION_VERSION}")
+        # Check schema compatibility. Legacy payloads used `version` instead.
+        schema_version = data.get("schema_version")
+        if schema_version is None:
+            schema_version = LEGACY_SERIALIZATION_SCHEMA_VERSION if "version" in data else "unknown"
+        if schema_version not in {LEGACY_SERIALIZATION_SCHEMA_VERSION, SERIALIZATION_SCHEMA_VERSION}:
+            raise UnsupportedVersionError(f"Unsupported schema_version: {schema_version}")
         
         # Check game type
         game_type = data.get("game_type", "unknown")
@@ -321,9 +341,16 @@ def deserialize_berkeley_game(data: Dict[str, Any]):
         scoresheet_move_stack = _move_stack_from_scoresheets(game._whites_scoresheet, game._blacks_scoresheet)
         if scoresheet_move_stack != move_stack:
             raise MalformedDataError("Scoresheet-derived moves do not match move_stack")
-        
-        # Regenerate possible moves list for current position
-        game._generate_possible_to_ask_list()
+
+        if schema_version == SERIALIZATION_SCHEMA_VERSION:
+            if "possible_to_ask" not in game_state:
+                raise MalformedDataError("Missing possible_to_ask in BerkeleyGame data")
+            game._possible_to_ask = deserialize_possible_to_ask(game_state["possible_to_ask"])
+        else:
+            # Legacy saved payloads did not preserve exact turn-state questions.
+            game._generate_possible_to_ask_list()
+            if game._must_use_pawns:
+                game._possible_to_ask = list(game._generate_possible_pawn_captures())
         
         return game
     except (KeyError, TypeError) as e:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -21,7 +21,7 @@ from kriegspiel.serialization import (
     serialize_kriegspiel_scoresheet, deserialize_kriegspiel_scoresheet,
     serialize_berkeley_game, deserialize_berkeley_game,
     save_game_to_json, load_game_from_json,
-    KriegspielJSONEncoder, SERIALIZATION_VERSION, _completed_moves_from_turn,
+    KriegspielJSONEncoder, SERIALIZATION_SCHEMA_VERSION, _completed_moves_from_turn,
     SerializationError, UnsupportedVersionError, MalformedDataError
 )
 
@@ -340,13 +340,15 @@ class TestBerkeleyGameSerializer:
         game = BerkeleyGame(any_rule=True)
         result = serialize_berkeley_game(game)
         
-        assert result["version"] == SERIALIZATION_VERSION
+        assert result["schema_version"] == SERIALIZATION_SCHEMA_VERSION
+        assert isinstance(result["library_version"], str)
         assert result["game_type"] == "BerkeleyGame"
         assert result["game_state"]["any_rule"] is True
         assert result["game_state"]["board_fen"] == chess.Board().fen()
         assert result["game_state"]["move_stack"] == []
         assert result["game_state"]["must_use_pawns"] is False
         assert result["game_state"]["game_over"] is False
+        assert result["game_state"]["possible_to_ask"]
         assert "white_scoresheet" in result["game_state"]
         assert "black_scoresheet" in result["game_state"]
     
@@ -409,6 +411,7 @@ class TestBerkeleyGameSerializer:
         assert deserialized._must_use_pawns == game._must_use_pawns
         assert deserialized._game_over == game._game_over
         assert deserialized.turn == game.turn
+        assert sorted(str(move) for move in deserialized.possible_to_ask) == sorted(str(move) for move in game.possible_to_ask)
         
         # Check that scoresheets are preserved
         assert len(deserialized._whites_scoresheet.moves_own) == len(game._whites_scoresheet.moves_own)
@@ -428,6 +431,14 @@ class TestBerkeleyGameSerializer:
         serialized["game_state"]["move_stack"] = ["e2e4"]
 
         with pytest.raises(MalformedDataError, match="Serialized move_stack does not match board_fen"):
+            deserialize_berkeley_game(serialized)
+
+    def test_deserialize_rejects_missing_possible_to_ask(self):
+        game = BerkeleyGame(any_rule=True)
+        serialized = serialize_berkeley_game(game)
+        serialized["game_state"].pop("possible_to_ask")
+
+        with pytest.raises(MalformedDataError, match="Missing possible_to_ask in BerkeleyGame data"):
             deserialize_berkeley_game(serialized)
 
     def test_deserialize_rejects_scoresheet_move_mismatch(self):
@@ -528,7 +539,7 @@ class TestJSONEncoder:
         
         # Should be valid JSON
         parsed = json.loads(json_str)
-        assert "version" in parsed
+        assert "schema_version" in parsed
         assert "game_type" in parsed  
         assert "game_state" in parsed
     
@@ -660,22 +671,22 @@ class TestErrorHandling:
     
     def test_unsupported_version(self):
         data = {
-            "version": "2.0",
+            "schema_version": 999,
             "game_type": "BerkeleyGame",
             "game_state": {}
         }
-        with pytest.raises(UnsupportedVersionError, match="Unsupported version: 2.0"):
+        with pytest.raises(UnsupportedVersionError, match="Unsupported schema_version: 999"):
             deserialize_berkeley_game(data)
     
     def test_malformed_berkeley_game_data(self):
         # Test with correct version but missing game_state
-        data = {"version": SERIALIZATION_VERSION, "game_type": "BerkeleyGame", "invalid": "data"}
+        data = {"schema_version": SERIALIZATION_SCHEMA_VERSION, "game_type": "BerkeleyGame", "invalid": "data"}
         with pytest.raises(MalformedDataError, match="Invalid BerkeleyGame data structure"):
             deserialize_berkeley_game(data)
     
     def test_invalid_board_fen(self):
         data = {
-            "version": SERIALIZATION_VERSION,
+            "schema_version": SERIALIZATION_SCHEMA_VERSION,
             "game_type": "BerkeleyGame",
             "game_state": {
                 "any_rule": True,
@@ -683,6 +694,7 @@ class TestErrorHandling:
                 "move_stack": [],
                 "must_use_pawns": False,
                 "game_over": False,
+                "possible_to_ask": [],
                 "white_scoresheet": {
                     "color": "WHITE",
                     "moves_own": [],
@@ -702,7 +714,7 @@ class TestErrorHandling:
     
     def test_invalid_game_type(self):
         data = {
-            "version": SERIALIZATION_VERSION,
+            "schema_version": SERIALIZATION_SCHEMA_VERSION,
             "game_type": "SomeOtherGame",
             "game_state": {}
         }
@@ -711,7 +723,7 @@ class TestErrorHandling:
 
     def test_invalid_move_stack_entry(self):
         data = {
-            "version": SERIALIZATION_VERSION,
+            "schema_version": SERIALIZATION_SCHEMA_VERSION,
             "game_type": "BerkeleyGame",
             "game_state": {
                 "any_rule": True,
@@ -719,6 +731,7 @@ class TestErrorHandling:
                 "move_stack": ["bad_move"],
                 "must_use_pawns": False,
                 "game_over": False,
+                "possible_to_ask": [],
                 "white_scoresheet": {
                     "color": "WHITE",
                     "moves_own": [],
@@ -738,7 +751,7 @@ class TestErrorHandling:
 
     def test_invalid_move_stack_entry_type(self):
         data = {
-            "version": SERIALIZATION_VERSION,
+            "schema_version": SERIALIZATION_SCHEMA_VERSION,
             "game_type": "BerkeleyGame",
             "game_state": {
                 "any_rule": True,
@@ -746,6 +759,7 @@ class TestErrorHandling:
                 "move_stack": [123],
                 "must_use_pawns": False,
                 "game_over": False,
+                "possible_to_ask": [],
                 "white_scoresheet": {
                     "color": "WHITE",
                     "moves_own": [],
@@ -765,7 +779,7 @@ class TestErrorHandling:
 
     def test_invalid_move_stack_type(self):
         data = {
-            "version": SERIALIZATION_VERSION,
+            "schema_version": SERIALIZATION_SCHEMA_VERSION,
             "game_type": "BerkeleyGame",
             "game_state": {
                 "any_rule": True,
@@ -773,6 +787,7 @@ class TestErrorHandling:
                 "move_stack": "e2e4",
                 "must_use_pawns": False,
                 "game_over": False,
+                "possible_to_ask": [],
                 "white_scoresheet": {
                     "color": "WHITE",
                     "moves_own": [],
@@ -788,6 +803,34 @@ class TestErrorHandling:
             }
         }
         with pytest.raises(MalformedDataError, match="Invalid move_stack: expected a list of UCI moves"):
+            deserialize_berkeley_game(data)
+
+    def test_invalid_possible_to_ask_type(self):
+        data = {
+            "schema_version": SERIALIZATION_SCHEMA_VERSION,
+            "game_type": "BerkeleyGame",
+            "game_state": {
+                "any_rule": True,
+                "board_fen": chess.Board().fen(),
+                "move_stack": [],
+                "must_use_pawns": False,
+                "game_over": False,
+                "possible_to_ask": "e2e4",
+                "white_scoresheet": {
+                    "color": "WHITE",
+                    "moves_own": [],
+                    "moves_opponent": [],
+                    "last_move_number": 0
+                },
+                "black_scoresheet": {
+                    "color": "BLACK",
+                    "moves_own": [],
+                    "moves_opponent": [],
+                    "last_move_number": 0
+                }
+            }
+        }
+        with pytest.raises(MalformedDataError, match="Invalid possible_to_ask: expected a list"):
             deserialize_berkeley_game(data)
 
     def test_completed_scoresheet_move_requires_chess_move(self):


### PR DESCRIPTION
## Summary
- add a stable schema_version for canonical BerkeleyGame serialization
- persist possible_to_ask in canonical payloads so active turns survive reloads exactly
- keep legacy payloads readable while decoupling storage compatibility from package version

## Testing
- remote validation pending on rpis02-cf
- local compileall sanity passed for package and tests