### PR TITLE
Enable ks-game branch coverage by default

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -28,7 +28,7 @@ import argparse
 
 def run_tests(test_args):
     """Run pytest with the given arguments."""
-    cmd = ["python", "-m", "pytest"] + test_args
+    cmd = [sys.executable, "-m", "pytest"] + test_args
     print(f"Running: {' '.join(cmd)}")
     return subprocess.run(cmd).returncode
 
@@ -42,7 +42,7 @@ def main():
     parser.add_argument("--rules", action="store_true", help="Run Kriegspiel rule tests only")
     parser.add_argument("--fast", action="store_true", help="Run fast tests (exclude slow)")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
-    parser.add_argument("--coverage", action="store_true", help="Include coverage report")
+    parser.add_argument("--coverage", action="store_true", help="Include line and branch coverage report")
     
     args = parser.parse_args()
     
@@ -53,7 +53,7 @@ def main():
         test_args.append("-v")
     
     if args.coverage:
-        test_args.extend(["--cov=kriegspiel", "--cov-report=term-missing"])
+        test_args.extend(["--cov=kriegspiel", "--cov-report=term-missing", "--cov-branch"])
     
     # Select test categories
     if args.unit:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = --cov-report term-missing --cov .
+addopts = --cov-report term-missing --cov --cov-branch .
 norecursedirs = env/* build .* dist
 markers =
     unit: Unit tests for individual components
@@ -20,6 +20,7 @@ exclude_lines =
     def __repr__
 
 [coverage:run]
+branch = True
 omit =
     env/*
     setup.py


### PR DESCRIPTION
## Summary
- enable branch coverage in the default pytest config for `ks-game`
- make the `run_tests.py` helper use the active Python interpreter instead of assuming `python` exists on `PATH`
- keep the explicit `--coverage` helper path aligned with the new branch-aware default

## Why
`ks-game` was already running coverage by default, but it only reported statement coverage. This makes branch coverage part of the default test flow so the repo reports both dimensions automatically. While validating that change, the helper script also exposed a portability issue: it spawned plain `python`, which can fail even when the active interpreter and repo environment are otherwise correct.

## Validation
- `/Users/fil/Developer/kriegspiel/ks-game/.venv/bin/python run_tests.py`
  - `172 passed`
  - statements: `553 / 557` = `99.28%`
  - branches: `202 / 210` = `96.19%`
  - combined coverage: `98.44%`

## Notes
- test/tooling only, so no package version bump
- remote validation on `rpis02-cf` will follow before merge
