### PR TITLE
Drop legacy v2 serialization support

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Kriegspiel v. 1.2.6
+
+- **Serialization**: removed support for pre-canonical payloads that used the old top-level `version` field instead of `schema_version`; schema `3` remains supported for current stored games and schema `4` remains the writer format
+
 ## Kriegspiel v. 1.2.5
 
 - **Ruleset Foundation**: Berkeley-family rule behavior now goes through an explicit ruleset policy layer, which keeps the hidden-board engine ready for future Cincinnati / Wild 16 support without hard-coding every variant into `BerkeleyGame`

--- a/kriegspiel/__init__.py
+++ b/kriegspiel/__init__.py
@@ -4,4 +4,4 @@ __author__ = "Alexander Filatov"
 
 __email__ = "alexander@kriegspiel.org"
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"

--- a/kriegspiel/serialization.py
+++ b/kriegspiel/serialization.py
@@ -71,7 +71,6 @@ from kriegspiel.snapshot import move_stack_from_scoresheets
 # Import version from main module
 from kriegspiel import __version__
 
-LEGACY_SERIALIZATION_SCHEMA_VERSION = 2
 PREVIOUS_SERIALIZATION_SCHEMA_VERSION = 3
 SERIALIZATION_SCHEMA_VERSION = 4
 
@@ -300,12 +299,11 @@ def serialize_berkeley_game(game) -> Dict[str, Any]:
 def deserialize_berkeley_game(data: Dict[str, Any]):
     """Deserialize dictionary to BerkeleyGame."""
     try:
-        # Check schema compatibility. Legacy payloads used `version` instead.
+        # Check schema compatibility. Live data is schema 3; new writes use schema 4.
         schema_version = data.get("schema_version")
         if schema_version is None:
-            schema_version = LEGACY_SERIALIZATION_SCHEMA_VERSION if "version" in data else "unknown"
+            raise UnsupportedVersionError("Missing schema_version")
         if schema_version not in {
-            LEGACY_SERIALIZATION_SCHEMA_VERSION,
             PREVIOUS_SERIALIZATION_SCHEMA_VERSION,
             SERIALIZATION_SCHEMA_VERSION,
         }:
@@ -332,11 +330,9 @@ def deserialize_berkeley_game(data: Dict[str, Any]):
         if ruleset_id is None:
             ruleset_id = "berkeley_any" if any_rule else "berkeley"
 
-        possible_to_ask = None
-        if schema_version in {PREVIOUS_SERIALIZATION_SCHEMA_VERSION, SERIALIZATION_SCHEMA_VERSION}:
-            if "possible_to_ask" not in game_state:
-                raise MalformedDataError("Missing possible_to_ask in BerkeleyGame data")
-            possible_to_ask = tuple(deserialize_possible_to_ask(game_state["possible_to_ask"]))
+        if "possible_to_ask" not in game_state:
+            raise MalformedDataError("Missing possible_to_ask in BerkeleyGame data")
+        possible_to_ask = tuple(deserialize_possible_to_ask(game_state["possible_to_ask"]))
 
         snapshot = BerkeleyGameSnapshot(
             ruleset_id=ruleset_id,

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -617,7 +617,7 @@ class TestEdgeCases:
         assert deserialized.ruleset_id == RULESET_BERKELEY_ANY
         assert deserialized.any_rule is True
 
-    def test_deserialize_legacy_version_field_still_works(self):
+    def test_deserialize_rejects_legacy_version_field_without_schema_version(self):
         game = BerkeleyGame(any_rule=True)
         result = serialize_berkeley_game(game)
         result.pop("schema_version")
@@ -625,10 +625,8 @@ class TestEdgeCases:
         result["game_state"].pop("ruleset_id")
         result["game_state"].pop("possible_to_ask")
 
-        deserialized = deserialize_berkeley_game(result)
-
-        assert deserialized.ruleset_id == RULESET_BERKELEY_ANY
-        assert deserialized.any_rule is True
+        with pytest.raises(UnsupportedVersionError, match="Missing schema_version"):
+            deserialize_berkeley_game(result)
     
     def test_serialize_game_after_any_question(self):
         game = BerkeleyGame(any_rule=True)


### PR DESCRIPTION
## Summary
- remove support for pre-canonical payloads that used the old top-level `version` field
- keep schema `3` support for the current Mongo data and schema `4` as the writer format
- bump package version to `1.2.6`

## Why
The live Mongo data was checked read-only and every `engine_state` payload is schema `3` with the canonical `game_state` shape. There are no v2 / top-level backend-shape payloads left to support.

## Testing
- `/Users/fil/Developer/kriegspiel/ks-game/.venv/bin/python run_tests.py`
- `/Users/fil/Developer/kriegspiel/ks-game/.venv/bin/python -m build`
