### PR TITLE
Add Wild 16 ruleset support to ks-game

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 [![PyPI version](https://badge.fury.io/py/kriegspiel.svg)](https://pypi.org/project/kriegspiel/)
 
-Python game engine for the Berkeley Kriegspiel referee rules.
+Python game engine for Berkeley-family Kriegspiel referee rules.
 
 Current scope:
 - Berkeley Kriegspiel
 - Berkeley + Any
+- Wild 16
 
 The package models the referee, not a UI. You interact with it by asking questions as `KriegspielMove` objects and reading `KriegspielAnswer` results.
 
@@ -39,11 +40,18 @@ game.save_game("game.json")
 loaded = BerkeleyGame.load_game("game.json")
 ```
 
+Wild 16 uses the same engine with an explicit ruleset:
+
+```python
+wild16 = BerkeleyGame(ruleset="wild16")
+print(wild16.current_turn_pawn_tries)
+```
+
 ## Main Concepts
 
 - `BerkeleyGame`: the referee and full hidden board state
 - `KriegspielMove`: a player question, either a normal move or `ASK_ANY`
-- `KriegspielAnswer`: the referee response, including move outcome, captures, and special announcements
+- `KriegspielAnswer`: the referee response, including move outcome, captures, special announcements, and variant-specific public metadata
 
 ## Links
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## Kriegspiel v. 1.3.0
+
+- **Wild 16 Support**: added first-class `wild16` ruleset handling, including typed pawn-vs-piece capture announcements, Wild 16 pawn-try counts, and private illegal-attempt behavior
+- **Answer Model**: `KriegspielAnswer` can now carry public capture-kind metadata and next-turn pawn-try counts for rulesets that announce them
+- **Serialization**: schema `5` now preserves the new Wild 16 answer metadata while remaining compatible with schema `3` and `4` payloads
+- **Testing**: added focused Wild 16 engine, serialization, and privacy regression coverage while keeping the full suite above the project coverage gate
+
 ## Kriegspiel v. 1.2.6
 
 - **Serialization**: removed support for pre-canonical payloads that used the old top-level `version` field instead of `schema_version`; schema `3` remains supported for current stored games and schema `4` remains the writer format

--- a/kriegspiel/__init__.py
+++ b/kriegspiel/__init__.py
@@ -4,4 +4,4 @@ __author__ = "Alexander Filatov"
 
 __email__ = "alexander@kriegspiel.org"
 
-__version__ = "1.2.6"
+__version__ = "1.3.0"

--- a/kriegspiel/berkeley.py
+++ b/kriegspiel/berkeley.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import enum
-
 import chess
 
 from kriegspiel.move import KriegspielMove as KSMove
@@ -12,8 +10,6 @@ from kriegspiel.move import MainAnnouncement as MA
 from kriegspiel.move import SpecialCaseAnnouncement as SCA
 
 from kriegspiel.move import KriegspielScoresheet as KSSS
-from kriegspiel.rulesets import RULESET_BERKELEY
-from kriegspiel.rulesets import RULESET_BERKELEY_ANY
 from kriegspiel.rulesets import resolve_ruleset_policy
 from kriegspiel.snapshot import BerkeleyGameSnapshot
 from kriegspiel.snapshot import move_stack_from_scoresheets
@@ -48,7 +44,7 @@ class BerkeleyGame(object):
             any_rule: Legacy compatibility flag for Berkeley+Any. When omitted,
                      Berkeley+Any remains the default.
             ruleset: Explicit ruleset identifier. Supported values are
-                     `berkeley` and `berkeley_any`.
+                     `berkeley`, `berkeley_any`, and `wild16`.
         """
         super(BerkeleyGame).__init__()
         self._ruleset = resolve_ruleset_policy(ruleset=ruleset, any_rule=any_rule)
@@ -99,9 +95,7 @@ class BerkeleyGame(object):
         if result.move_done:
             self._generate_possible_to_ask_list()
         self._ruleset.apply_post_answer_constraints(self, result)
-        # Possible to ask about a move only once
-        if result.main_announcement in (MA.ILLEGAL_MOVE, MA.NO_ANY):
-            # For `has any` already deleted
+        if self._ruleset.should_discard_attempt(move, result):
             self._discard_possible_to_ask(move)
         return result
 
@@ -109,26 +103,32 @@ class BerkeleyGame(object):
         """
         return (MoveAnnouncement, captured_square, SpecialCaseAnnouncement)
         """
-        # If a player asks for a non-sense move. Stop it.
-        if move not in self._possible_to_ask_set:
-            return KSAnswer(MA.IMPOSSIBLE_TO_ASK)
-
         if move.question_type == QA.COMMON:
+            if move not in self._possible_to_ask_set:
+                return KSAnswer(self._ruleset.classify_impossible_common_attempt())
             # Player asks about a common move
             if self._is_legal_move(move.chess_move):
                 # Move is legal in normal chess
                 # Perform normal move
-                captured_square = self._make_move(move.chess_move)
+                captured_square, captured_piece_announcement = self._make_move(move.chess_move)
                 special_case = self._check_special_cases()
+                next_turn_pawn_tries = self._ruleset.next_turn_pawn_tries(self)
+                answer_kwargs = {"special_announcement": special_case}
+                if next_turn_pawn_tries is not None:
+                    answer_kwargs["next_turn_pawn_tries"] = next_turn_pawn_tries
                 if captured_square is not None:
                     # If it was capture
-                    return KSAnswer(MA.CAPTURE_DONE, capture_at_square=captured_square, special_announcement=special_case)
+                    answer_kwargs["capture_at_square"] = captured_square
+                    if captured_piece_announcement is not None:
+                        answer_kwargs["captured_piece_announcement"] = captured_piece_announcement
+                    return KSAnswer(MA.CAPTURE_DONE, **answer_kwargs)
                 # If it was a regular move, and NO captures
-                return KSAnswer(MA.REGULAR_MOVE, special_announcement=special_case)
+                return KSAnswer(MA.REGULAR_MOVE, **answer_kwargs)
             # If a move is illegal from the referee's perspective. But it's
             # was a possible move from asking player's perspective.
-            # IMPORTANT: That's a new info for both players. Hence must be announced.
             return KSAnswer(MA.ILLEGAL_MOVE)
+        if move not in self._possible_to_ask_set:
+            return KSAnswer(MA.IMPOSSIBLE_TO_ASK)
         policy_answer = self._ruleset.handle_special_question(self, move)
         if policy_answer is not None:
             return policy_answer
@@ -140,10 +140,12 @@ class BerkeleyGame(object):
             current_turn = not current_turn
         if current_turn == chess.WHITE:
             self._whites_scoresheet.record_move_own(move, answer)
-            self._blacks_scoresheet.record_move_opponent(move.question_type, answer)
+            if self._ruleset.should_record_opponent_answer(move, answer):
+                self._blacks_scoresheet.record_move_opponent(move.question_type, answer)
         else:
             self._blacks_scoresheet.record_move_own(move, answer)
-            self._whites_scoresheet.record_move_opponent(move.question_type, answer)
+            if self._ruleset.should_record_opponent_answer(move, answer):
+                self._whites_scoresheet.record_move_opponent(move.question_type, answer)
 
     def is_game_over(self):
         """
@@ -282,17 +284,40 @@ class BerkeleyGame(object):
             else:
                 return move.to_square + 8
 
+    def _get_captured_piece(self, move):
+        """Return the piece removed by a capture before the move is pushed."""
+        if not self._board.is_capture(move):
+            return None
+        captured_square = self._get_captured_square(move)
+        return self._board.piece_at(captured_square)
+
     def _make_move(self, move):
         """
         Make the move on the referee's board
-        and return square with capture.
+        and return capture details.
         """
         self._must_use_pawns = False
         captured_square = None
+        captured_piece_announcement = None
         if self._board.is_capture(move):
             captured_square = self._get_captured_square(move)
+            captured_piece = self._get_captured_piece(move)
+            captured_piece_announcement = self._ruleset.captured_piece_announcement_for(captured_piece)
         self._board.push(move)
-        return captured_square
+        return captured_square, captured_piece_announcement
+
+    def _legal_pawn_capture_moves(self):
+        """Return legal pawn captures for the active player in the true position."""
+        pawn_squares = self._board.pieces(chess.PAWN, self._board.turn)
+        return [
+            move
+            for move in self._board.legal_moves
+            if move.from_square in pawn_squares and self._board.is_capture(move)
+        ]
+
+    def _count_legal_pawn_captures(self):
+        """Count legal pawn captures for the active player in the true position."""
+        return len(self._legal_pawn_capture_moves())
 
     def _has_any_pawn_captures(self):
         """
@@ -304,12 +329,7 @@ class BerkeleyGame(object):
             bool: True if there are any legal pawn capture moves available,
                  False if no pawn captures are possible.
         """
-        pawn_squares = self._board.pieces(chess.PAWN, self._board.turn)
-        for move in self._board.legal_moves:
-            if move.from_square in pawn_squares:
-                if self._board.is_capture(move):
-                    return True
-        return False
+        return self._count_legal_pawn_captures() > 0
 
     def _is_legal_move(self, move):
         """
@@ -440,6 +460,16 @@ class BerkeleyGame(object):
     def ruleset_id(self):
         """Explicit ruleset identifier for snapshot and serialization APIs."""
         return self._ruleset.identifier
+
+    @property
+    def current_turn_pawn_tries(self):
+        """
+        Get the Wild 16 style pawn-capture count for the current player to move.
+
+        Returns:
+            int or None: Legal pawn-capture count when the active ruleset announces it.
+        """
+        return self._ruleset.next_turn_pawn_tries(self)
 
     @property
     def must_use_pawns(self):

--- a/kriegspiel/move.py
+++ b/kriegspiel/move.py
@@ -232,6 +232,14 @@ SINGLE_CHECK = [
 ]
 
 
+@enum.unique
+class CapturedPieceAnnouncement(enum.Enum):
+    """Public capture detail for variants that announce pawn vs piece."""
+
+    PAWN = 1
+    PIECE = 2
+
+
 class KriegspielAnswer(object):
     """
     Represents the referee's response to a Kriegspiel move question.
@@ -252,9 +260,14 @@ class KriegspielAnswer(object):
             **kwargs: Additional answer details:
                 capture_at_square (int): Required for CAPTURE_DONE. Square number (0-63)
                                        where the capture occurred.
+                captured_piece_announcement (CapturedPieceAnnouncement): Optional public
+                                    capture detail for variants that distinguish pawn
+                                    captures from other piece captures.
                 special_announcement: Optional special game state from SpecialCaseAnnouncement
                                     enum. Can be a single value or tuple for double check.
                                     For CHECK_DOUBLE, provide (CHECK_DOUBLE, [check1, check2]).
+                next_turn_pawn_tries (int): Optional Wild 16 style count of legal pawn
+                                    captures available for the next player to move.
         
         Raises:
             TypeError: If main_announcement is not a MainAnnouncement enum value,
@@ -270,10 +283,12 @@ class KriegspielAnswer(object):
 
         self._main_announcement = main_announcement
         self._capture_at_square = None
+        self._captured_piece_announcement = None
         self._special_announcement = SpecialCaseAnnouncement.NONE
         self._move_done = False
         self._check_1 = None
         self._check_2 = None
+        self._next_turn_pawn_tries = None
 
         if main_announcement == MainAnnouncement.CAPTURE_DONE:
             # Validation, that when capture is done, then valid square should
@@ -284,6 +299,13 @@ class KriegspielAnswer(object):
             if not (0 <= square <= 63):  # Chess board has 64 squares (0-63)
                 raise ValueError(f"Invalid square number: {square}. Must be 0-63.")
             self._capture_at_square = square
+            if "captured_piece_announcement" in kwargs:
+                captured_piece_announcement = kwargs["captured_piece_announcement"]
+                if not isinstance(captured_piece_announcement, CapturedPieceAnnouncement):
+                    raise TypeError("captured_piece_announcement must be a CapturedPieceAnnouncement")
+                self._captured_piece_announcement = captured_piece_announcement
+        elif "captured_piece_announcement" in kwargs:
+            raise TypeError("captured_piece_announcement is only valid for CAPTURE_DONE")
 
         if "special_announcement" in kwargs:
             sca = kwargs["special_announcement"]
@@ -311,6 +333,14 @@ class KriegspielAnswer(object):
                 raise TypeError(
                     "special_announcement must be a SpecialCaseAnnouncement or a CHECK_DOUBLE tuple"
                 )
+
+        if "next_turn_pawn_tries" in kwargs:
+            next_turn_pawn_tries = kwargs["next_turn_pawn_tries"]
+            if not isinstance(next_turn_pawn_tries, int):
+                raise TypeError("next_turn_pawn_tries must be an integer")
+            if next_turn_pawn_tries < 0:
+                raise ValueError("next_turn_pawn_tries must be non-negative")
+            self._next_turn_pawn_tries = next_turn_pawn_tries
 
         if self._main_announcement in MOVE_DONE:
             self._move_done = True
@@ -348,6 +378,16 @@ class KriegspielAnswer(object):
         return self._special_announcement
 
     @property
+    def captured_piece_announcement(self):
+        """
+        Get the public capture kind for variants that expose pawn vs piece.
+
+        Returns:
+            CapturedPieceAnnouncement or None: Public capture kind when available.
+        """
+        return self._captured_piece_announcement
+
+    @property
     def move_done(self):
         """
         Check if the move was successfully completed.
@@ -357,6 +397,16 @@ class KriegspielAnswer(object):
                  False if move was illegal or impossible.
         """
         return self._move_done
+
+    @property
+    def next_turn_pawn_tries(self):
+        """
+        Get the next player's legal pawn-capture count when the ruleset announces it.
+
+        Returns:
+            int or None: Wild 16 style pawn-try count for the next player to move.
+        """
+        return self._next_turn_pawn_tries
 
     @property
     def check_1(self):
@@ -392,7 +442,12 @@ class KriegspielAnswer(object):
         if isinstance(self._capture_at_square, int):
             capture_at = chess.SQUARE_NAMES[self._capture_at_square]
 
-        main_data = [f"capture_at={capture_at}", f"special_case={self._special_announcement}"]
+        main_data = [
+            f"capture_at={capture_at}",
+            f"captured_piece={self._captured_piece_announcement}",
+            f"special_case={self._special_announcement}",
+            f"next_turn_pawn_tries={self._next_turn_pawn_tries}",
+        ]
 
         if self._check_1 is not None or self._check_2 is not None:
             extra_data = f"check_1={self._check_1}, check_2={self._check_2}"
@@ -404,7 +459,9 @@ class KriegspielAnswer(object):
         return (
             self._main_announcement,
             self._capture_at_square,
+            self._captured_piece_announcement,
             self._special_announcement,
+            self._next_turn_pawn_tries,
             self._check_1,
             self._check_2,
         )
@@ -413,7 +470,9 @@ class KriegspielAnswer(object):
         return (
             self._main_announcement.value,
             self._capture_at_square,
+            self._captured_piece_announcement.value if self._captured_piece_announcement is not None else -1,
             self._special_announcement.value,
+            self._next_turn_pawn_tries if self._next_turn_pawn_tries is not None else -1,
             self._check_1.value if self._check_1 is not None else -1,
             self._check_2.value if self._check_2 is not None else -1,
         )

--- a/kriegspiel/rulesets.py
+++ b/kriegspiel/rulesets.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import chess
+
 from kriegspiel.move import KriegspielAnswer as KSAnswer
+from kriegspiel.move import CapturedPieceAnnouncement as CPA
 from kriegspiel.move import KriegspielMove as KSMove
 from kriegspiel.move import MainAnnouncement as MA
 from kriegspiel.move import QuestionAnnouncement as QA
@@ -12,6 +15,7 @@ from kriegspiel.move import QuestionAnnouncement as QA
 
 RULESET_BERKELEY = "berkeley"
 RULESET_BERKELEY_ANY = "berkeley_any"
+RULESET_WILD16 = "wild16"
 
 
 @dataclass(frozen=True)
@@ -26,10 +30,18 @@ class BerkeleyRulesetPolicy:
 
     identifier: str
     allow_ask_any: bool
+    invalid_common_attempt_result: MA
+    discard_illegal_attempts: bool
+    public_illegal_attempts: bool
+    typed_capture_announcements: bool
+    announce_next_turn_pawn_tries: bool
 
     def add_special_questions(self, possibilities: set[KSMove]) -> None:
         if self.allow_ask_any:
             possibilities.add(KSMove(QA.ASK_ANY))
+
+    def classify_impossible_common_attempt(self) -> MA:
+        return self.invalid_common_attempt_result
 
     def handle_special_question(self, game, move: KSMove):
         if move.question_type != QA.ASK_ANY:
@@ -49,6 +61,32 @@ class BerkeleyRulesetPolicy:
             pawn_captures = set(game._generate_possible_pawn_captures())
             game._set_possible_to_ask(game._possible_to_ask_set - pawn_captures)
 
+    def should_record_opponent_answer(self, move: KSMove, answer: KSAnswer) -> bool:
+        if answer.main_announcement == MA.IMPOSSIBLE_TO_ASK:
+            return False
+        if answer.main_announcement == MA.ILLEGAL_MOVE and not self.public_illegal_attempts:
+            return False
+        return True
+
+    def should_discard_attempt(self, move: KSMove, answer: KSAnswer) -> bool:
+        if answer.main_announcement == MA.NO_ANY:
+            return True
+        if answer.main_announcement == MA.ILLEGAL_MOVE:
+            return self.discard_illegal_attempts
+        return False
+
+    def captured_piece_announcement_for(self, captured_piece) -> CPA | None:
+        if not self.typed_capture_announcements or captured_piece is None:
+            return None
+        if captured_piece.piece_type == chess.PAWN:
+            return CPA.PAWN
+        return CPA.PIECE
+
+    def next_turn_pawn_tries(self, game) -> int | None:
+        if not self.announce_next_turn_pawn_tries or game.game_over:
+            return None
+        return game._count_legal_pawn_captures()
+
 
 def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None = None) -> BerkeleyRulesetPolicy:
     """Resolve legacy `any_rule` calls into an explicit ruleset policy."""
@@ -63,7 +101,33 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             )
 
     if ruleset == RULESET_BERKELEY_ANY:
-        return BerkeleyRulesetPolicy(identifier=ruleset, allow_ask_any=True)
+        return BerkeleyRulesetPolicy(
+            identifier=ruleset,
+            allow_ask_any=True,
+            invalid_common_attempt_result=MA.IMPOSSIBLE_TO_ASK,
+            discard_illegal_attempts=True,
+            public_illegal_attempts=True,
+            typed_capture_announcements=False,
+            announce_next_turn_pawn_tries=False,
+        )
     if ruleset == RULESET_BERKELEY:
-        return BerkeleyRulesetPolicy(identifier=ruleset, allow_ask_any=False)
+        return BerkeleyRulesetPolicy(
+            identifier=ruleset,
+            allow_ask_any=False,
+            invalid_common_attempt_result=MA.IMPOSSIBLE_TO_ASK,
+            discard_illegal_attempts=True,
+            public_illegal_attempts=True,
+            typed_capture_announcements=False,
+            announce_next_turn_pawn_tries=False,
+        )
+    if ruleset == RULESET_WILD16:
+        return BerkeleyRulesetPolicy(
+            identifier=ruleset,
+            allow_ask_any=False,
+            invalid_common_attempt_result=MA.ILLEGAL_MOVE,
+            discard_illegal_attempts=False,
+            public_illegal_attempts=False,
+            typed_capture_announcements=True,
+            announce_next_turn_pawn_tries=True,
+        )
     raise ValueError(f"Unsupported ruleset: {ruleset!r}")

--- a/kriegspiel/serialization.py
+++ b/kriegspiel/serialization.py
@@ -8,8 +8,8 @@ Kriegspiel game components using JSON format with custom encoders/decoders.
 
 JSON Schema Structure:
 {
-  "schema_version": 4,
-  "library_version": "1.2.5",
+  "schema_version": 5,
+  "library_version": "1.3.0",
   "game_type": "BerkeleyGame",
   "game_state": {
     "ruleset_id": "berkeley_any",
@@ -45,7 +45,9 @@ moves_own/moves_opponent: [
       {  // KriegspielAnswer
         "main_announcement": "REGULAR_MOVE" | "CAPTURE_DONE" | ...,
         "capture_at_square": int | null,
+        "captured_piece_announcement": "PAWN" | "PIECE" | null,
         "special_announcement": "NONE" | "CHECK_RANK" | ...,
+        "next_turn_pawn_tries": int | null,
         "check_1": "CHECK_RANK" | null,  // For double check
         "check_2": "CHECK_FILE" | null   // For double check
       }
@@ -60,7 +62,7 @@ from typing import Any, Dict, List, Optional, Union
 import chess
 
 from kriegspiel.move import (
-    QuestionAnnouncement, MainAnnouncement, SpecialCaseAnnouncement,
+    QuestionAnnouncement, MainAnnouncement, SpecialCaseAnnouncement, CapturedPieceAnnouncement,
     KriegspielMove, KriegspielAnswer, KriegspielScoresheet
 )
 from kriegspiel.snapshot import BerkeleyGameSnapshot
@@ -71,8 +73,9 @@ from kriegspiel.snapshot import move_stack_from_scoresheets
 # Import version from main module
 from kriegspiel import __version__
 
-PREVIOUS_SERIALIZATION_SCHEMA_VERSION = 3
-SERIALIZATION_SCHEMA_VERSION = 4
+LEGACY_SERIALIZATION_SCHEMA_VERSION = 3
+PREVIOUS_SERIALIZATION_SCHEMA_VERSION = 4
+SERIALIZATION_SCHEMA_VERSION = 5
 
 
 class SerializationError(Exception):
@@ -97,7 +100,7 @@ class KriegspielJSONEncoder(json.JSONEncoder):
         """Convert Kriegspiel objects to JSON-serializable format."""
         if isinstance(obj, chess.Move):
             return obj.uci()
-        elif isinstance(obj, (QuestionAnnouncement, MainAnnouncement, SpecialCaseAnnouncement)):
+        elif isinstance(obj, (QuestionAnnouncement, MainAnnouncement, SpecialCaseAnnouncement, CapturedPieceAnnouncement)):
             return obj.name
         elif isinstance(obj, KriegspielMove):
             return serialize_kriegspiel_move(obj)
@@ -126,7 +129,14 @@ def deserialize_chess_move(uci_str: Optional[str]) -> Optional[chess.Move]:
         raise MalformedDataError(f"Invalid UCI move string: {uci_str}") from e
 
 
-def serialize_enum(enum_val: Union[QuestionAnnouncement, MainAnnouncement, SpecialCaseAnnouncement]) -> str:
+def serialize_enum(
+    enum_val: Union[
+        QuestionAnnouncement,
+        MainAnnouncement,
+        SpecialCaseAnnouncement,
+        CapturedPieceAnnouncement,
+    ]
+) -> str:
     """Serialize enum to its name string."""
     return enum_val.name
 
@@ -153,6 +163,14 @@ def deserialize_special_case_announcement(name: str) -> SpecialCaseAnnouncement:
         return SpecialCaseAnnouncement[name]
     except KeyError as e:
         raise MalformedDataError(f"Invalid SpecialCaseAnnouncement: {name}") from e
+
+
+def deserialize_captured_piece_announcement(name: str) -> CapturedPieceAnnouncement:
+    """Deserialize string name to CapturedPieceAnnouncement enum."""
+    try:
+        return CapturedPieceAnnouncement[name]
+    except KeyError as e:
+        raise MalformedDataError(f"Invalid CapturedPieceAnnouncement: {name}") from e
 
 
 def serialize_kriegspiel_move(move: KriegspielMove) -> Dict[str, Any]:
@@ -192,7 +210,13 @@ def serialize_kriegspiel_answer(answer: KriegspielAnswer) -> Dict[str, Any]:
     return {
         "main_announcement": serialize_enum(answer.main_announcement),
         "capture_at_square": answer.capture_at_square,
+        "captured_piece_announcement": (
+            serialize_enum(answer.captured_piece_announcement)
+            if answer.captured_piece_announcement is not None
+            else None
+        ),
         "special_announcement": serialize_enum(answer.special_announcement),
+        "next_turn_pawn_tries": answer.next_turn_pawn_tries,
         "check_1": serialize_enum(answer.check_1) if answer.check_1 is not None else None,
         "check_2": serialize_enum(answer.check_2) if answer.check_2 is not None else None
     }
@@ -208,6 +232,12 @@ def deserialize_kriegspiel_answer(data: Dict[str, Any]) -> KriegspielAnswer:
         
         if data.get("capture_at_square") is not None:
             kwargs["capture_at_square"] = data["capture_at_square"]
+        if data.get("captured_piece_announcement") is not None:
+            kwargs["captured_piece_announcement"] = deserialize_captured_piece_announcement(
+                data["captured_piece_announcement"]
+            )
+        if data.get("next_turn_pawn_tries") is not None:
+            kwargs["next_turn_pawn_tries"] = data["next_turn_pawn_tries"]
         
         special_announcement = deserialize_special_case_announcement(data["special_announcement"])
         
@@ -299,11 +329,12 @@ def serialize_berkeley_game(game) -> Dict[str, Any]:
 def deserialize_berkeley_game(data: Dict[str, Any]):
     """Deserialize dictionary to BerkeleyGame."""
     try:
-        # Check schema compatibility. Live data is schema 3; new writes use schema 4.
+        # Check schema compatibility. Live data uses schema 3/4; new writes use schema 5.
         schema_version = data.get("schema_version")
         if schema_version is None:
             raise UnsupportedVersionError("Missing schema_version")
         if schema_version not in {
+            LEGACY_SERIALIZATION_SCHEMA_VERSION,
             PREVIOUS_SERIALIZATION_SCHEMA_VERSION,
             SERIALIZATION_SCHEMA_VERSION,
         }:

--- a/tests/test_berkeley.py
+++ b/tests/test_berkeley.py
@@ -20,12 +20,25 @@ from kriegspiel.move import KriegspielMove as KSMove
 from kriegspiel.move import QuestionAnnouncement as QA
 
 from kriegspiel.move import KriegspielAnswer as KSAnswer
+from kriegspiel.move import CapturedPieceAnnouncement as CPA
 from kriegspiel.move import MainAnnouncement as MA
 from kriegspiel.move import SpecialCaseAnnouncement as SCA
 from kriegspiel.rulesets import RULESET_BERKELEY
 from kriegspiel.rulesets import RULESET_BERKELEY_ANY
+from kriegspiel.rulesets import RULESET_WILD16
 from kriegspiel.rulesets import resolve_ruleset_policy
 from kriegspiel.snapshot import BerkeleyGameSnapshot
+
+
+def _build_hidden_blocker_wild16_game():
+    game = BerkeleyGame(ruleset=RULESET_WILD16)
+    game._board.clear()
+    game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.E8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.C1, chess.Piece(chess.BISHOP, chess.WHITE))
+    game._board.set_piece_at(chess.D2, chess.Piece(chess.KNIGHT, chess.BLACK))
+    game._generate_possible_to_ask_list()
+    return game
 
 
 @pytest.mark.integration
@@ -76,7 +89,16 @@ def test_conflicting_ruleset_arguments_are_rejected():
 
 def test_unknown_ruleset_is_rejected():
     with pytest.raises(ValueError, match="Unsupported ruleset"):
-        BerkeleyGame(ruleset="wild16")
+        BerkeleyGame(ruleset="unknown_variant")
+
+
+def test_explicit_ruleset_can_enable_wild16():
+    g = BerkeleyGame(ruleset=RULESET_WILD16)
+
+    assert g.ruleset_id == RULESET_WILD16
+    assert g.any_rule is False
+    assert KSMove(QA.ASK_ANY) not in g.possible_to_ask
+    assert g.current_turn_pawn_tries == 0
 
 
 def test_ruleset_policy_returns_none_for_non_special_question():
@@ -89,6 +111,82 @@ def test_ruleset_policy_rejects_ask_any_when_disabled():
     policy = resolve_ruleset_policy(ruleset=RULESET_BERKELEY)
 
     assert policy.handle_special_question(BerkeleyGame(any_rule=False), KSMove(QA.ASK_ANY)) == KSAnswer(MA.IMPOSSIBLE_TO_ASK)
+
+
+def test_wild16_policy_uses_private_illegal_moves():
+    policy = resolve_ruleset_policy(ruleset=RULESET_WILD16)
+
+    assert policy.classify_impossible_common_attempt() == MA.ILLEGAL_MOVE
+    assert policy.public_illegal_attempts is False
+    assert policy.discard_illegal_attempts is False
+
+
+def test_wild16_illegal_attempt_is_private_to_mover():
+    g = BerkeleyGame(ruleset=RULESET_WILD16)
+
+    result = g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E5)))
+
+    assert result == KSAnswer(MA.ILLEGAL_MOVE)
+    assert len(g._whites_scoresheet.moves_own) == 1
+    assert g._whites_scoresheet.moves_own[0][0][1] == KSAnswer(MA.ILLEGAL_MOVE)
+    assert g._blacks_scoresheet.moves_opponent == []
+
+
+def test_wild16_hidden_illegal_attempt_stays_repeatable():
+    g = _build_hidden_blocker_wild16_game()
+    move = KSMove(QA.COMMON, chess.Move(chess.C1, chess.H6))
+
+    assert move in g.possible_to_ask
+    assert g.ask_for(move) == KSAnswer(MA.ILLEGAL_MOVE)
+    assert g.ask_for(move) == KSAnswer(MA.ILLEGAL_MOVE)
+    assert len(g._whites_scoresheet.moves_own[0]) == 2
+    assert g._blacks_scoresheet.moves_opponent == []
+
+
+def test_wild16_completed_move_announces_next_turn_pawn_tries():
+    g = BerkeleyGame(ruleset=RULESET_WILD16)
+
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+    result = g.ask_for(KSMove(QA.COMMON, chess.Move(chess.D7, chess.D5)))
+
+    assert result == KSAnswer(MA.REGULAR_MOVE, next_turn_pawn_tries=1)
+    assert g.current_turn_pawn_tries == 1
+
+
+def test_wild16_capture_announces_pawn_kind():
+    g = BerkeleyGame(ruleset=RULESET_WILD16)
+    g._board.clear()
+    g._board.set_piece_at(chess.A1, chess.Piece(chess.KING, chess.WHITE))
+    g._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    g._board.set_piece_at(chess.E4, chess.Piece(chess.PAWN, chess.WHITE))
+    g._board.set_piece_at(chess.D5, chess.Piece(chess.PAWN, chess.BLACK))
+    g._generate_possible_to_ask_list()
+
+    assert g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E4, chess.D5))) == KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.D5,
+        captured_piece_announcement=CPA.PAWN,
+        next_turn_pawn_tries=0,
+    )
+
+
+def test_wild16_pawn_try_count_ignores_captures_that_do_not_escape_check():
+    g = BerkeleyGame(ruleset=RULESET_WILD16)
+    g._board.clear()
+    g._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    g._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    g._board.set_piece_at(chess.D2, chess.Piece(chess.PAWN, chess.WHITE))
+    g._board.set_piece_at(chess.A1, chess.Piece(chess.ROOK, chess.BLACK))
+    g._board.set_piece_at(chess.E3, chess.Piece(chess.BISHOP, chess.BLACK))
+    g._generate_possible_to_ask_list()
+
+    assert g.current_turn_pawn_tries == 0
+
+
+def test_wild16_ask_any_is_not_supported():
+    g = BerkeleyGame(ruleset=RULESET_WILD16)
+
+    assert g.ask_for(KSMove(QA.ASK_ANY)) == KSAnswer(MA.IMPOSSIBLE_TO_ASK)
 
 
 def test_black_illegal_after_any_true():

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -20,6 +20,7 @@ from kriegspiel.move import KriegspielMove as KSMove
 from kriegspiel.move import QuestionAnnouncement as QA
 
 from kriegspiel.move import KriegspielAnswer as KSAnswer
+from kriegspiel.move import CapturedPieceAnnouncement as CPA
 from kriegspiel.move import MainAnnouncement as MA
 from kriegspiel.move import SpecialCaseAnnouncement as SCA
 
@@ -206,6 +207,42 @@ def test_captue_at_square():
     assert a.capture_at_square == chess.E2
 
 
+def test_capture_answer_can_include_public_capture_kind():
+    answer = KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.E4,
+        captured_piece_announcement=CPA.PAWN,
+    )
+
+    assert answer.captured_piece_announcement == CPA.PAWN
+
+
+def test_capture_answer_rejects_invalid_public_capture_kind():
+    with pytest.raises(TypeError, match="captured_piece_announcement must be a CapturedPieceAnnouncement"):
+        KSAnswer(
+            MA.CAPTURE_DONE,
+            capture_at_square=chess.E4,
+            captured_piece_announcement="pawn",
+        )
+
+
+def test_non_capture_answer_rejects_public_capture_kind():
+    with pytest.raises(TypeError, match="captured_piece_announcement is only valid for CAPTURE_DONE"):
+        KSAnswer(MA.REGULAR_MOVE, captured_piece_announcement=CPA.PAWN)
+
+
+def test_next_turn_pawn_tries_validation():
+    answer = KSAnswer(MA.REGULAR_MOVE, next_turn_pawn_tries=2)
+
+    assert answer.next_turn_pawn_tries == 2
+
+    with pytest.raises(TypeError, match="next_turn_pawn_tries must be an integer"):
+        KSAnswer(MA.REGULAR_MOVE, next_turn_pawn_tries="2")
+
+    with pytest.raises(ValueError, match="next_turn_pawn_tries must be non-negative"):
+        KSAnswer(MA.REGULAR_MOVE, next_turn_pawn_tries=-1)
+
+
 @pytest.mark.unit
 def test_capture_square_range_validation():
     """Test that capture squares must be within valid range (0-63)."""
@@ -314,7 +351,8 @@ def test_ksanswer_str_with_double_check_payload():
 
     assert str(answer) == (
         "<KriegspielAnswer: MainAnnouncement.REGULAR_MOVE, "
-        "capture_at=None, special_case=SpecialCaseAnnouncement.CHECK_DOUBLE, "
+        "capture_at=None, captured_piece=None, special_case=SpecialCaseAnnouncement.CHECK_DOUBLE, "
+        "next_turn_pawn_tries=None, "
         "check_1=SpecialCaseAnnouncement.CHECK_FILE, "
         "check_2=SpecialCaseAnnouncement.CHECK_KNIGHT>"
     )

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -8,7 +8,7 @@ import chess
 from types import SimpleNamespace
 
 from kriegspiel.move import (
-    QuestionAnnouncement, MainAnnouncement, SpecialCaseAnnouncement,
+    QuestionAnnouncement, MainAnnouncement, SpecialCaseAnnouncement, CapturedPieceAnnouncement,
     KriegspielMove, KriegspielAnswer, KriegspielScoresheet
 )
 from kriegspiel.berkeley import BerkeleyGame
@@ -26,6 +26,7 @@ from kriegspiel.serialization import (
 )
 from kriegspiel.rulesets import RULESET_BERKELEY
 from kriegspiel.rulesets import RULESET_BERKELEY_ANY
+from kriegspiel.rulesets import RULESET_WILD16
 
 
 class TestChessMoveSerializer:
@@ -161,7 +162,9 @@ class TestKriegspielAnswerSerializer:
         expected = {
             "main_announcement": "REGULAR_MOVE",
             "capture_at_square": None,
+            "captured_piece_announcement": None,
             "special_announcement": "NONE",
+            "next_turn_pawn_tries": None,
             "check_1": None,
             "check_2": None
         }
@@ -173,7 +176,9 @@ class TestKriegspielAnswerSerializer:
         expected = {
             "main_announcement": "CAPTURE_DONE",
             "capture_at_square": 28,
+            "captured_piece_announcement": None,
             "special_announcement": "NONE",
+            "next_turn_pawn_tries": None,
             "check_1": None,
             "check_2": None
         }
@@ -186,7 +191,9 @@ class TestKriegspielAnswerSerializer:
         expected = {
             "main_announcement": "REGULAR_MOVE",
             "capture_at_square": None,
+            "captured_piece_announcement": None,
             "special_announcement": "CHECK_RANK",
+            "next_turn_pawn_tries": None,
             "check_1": None,
             "check_2": None
         }
@@ -201,11 +208,31 @@ class TestKriegspielAnswerSerializer:
         expected = {
             "main_announcement": "REGULAR_MOVE",
             "capture_at_square": None,
+            "captured_piece_announcement": None,
             "special_announcement": "CHECK_DOUBLE",
+            "next_turn_pawn_tries": None,
             "check_1": "CHECK_RANK",
             "check_2": "CHECK_FILE"
         }
         assert result == expected
+
+    def test_serialize_wild16_answer_fields(self):
+        answer = KriegspielAnswer(
+            MainAnnouncement.CAPTURE_DONE,
+            capture_at_square=28,
+            captured_piece_announcement=CapturedPieceAnnouncement.PAWN,
+            next_turn_pawn_tries=2,
+        )
+
+        assert serialize_kriegspiel_answer(answer) == {
+            "main_announcement": "CAPTURE_DONE",
+            "capture_at_square": 28,
+            "captured_piece_announcement": "PAWN",
+            "special_announcement": "NONE",
+            "next_turn_pawn_tries": 2,
+            "check_1": None,
+            "check_2": None,
+        }
     
     def test_deserialize_regular_move_answer(self):
         data = {
@@ -245,6 +272,24 @@ class TestKriegspielAnswerSerializer:
                                                       [SpecialCaseAnnouncement.CHECK_RANK,
                                                        SpecialCaseAnnouncement.CHECK_FILE]))
         assert result == expected
+
+    def test_deserialize_wild16_answer_fields(self):
+        data = {
+            "main_announcement": "CAPTURE_DONE",
+            "capture_at_square": 28,
+            "captured_piece_announcement": "PIECE",
+            "special_announcement": "NONE",
+            "next_turn_pawn_tries": 3,
+            "check_1": None,
+            "check_2": None,
+        }
+
+        assert deserialize_kriegspiel_answer(data) == KriegspielAnswer(
+            MainAnnouncement.CAPTURE_DONE,
+            capture_at_square=28,
+            captured_piece_announcement=CapturedPieceAnnouncement.PIECE,
+            next_turn_pawn_tries=3,
+        )
     
     def test_kriegspiel_answer_roundtrip(self):
         answers = [
@@ -354,6 +399,13 @@ class TestBerkeleyGameSerializer:
         assert result["game_state"]["possible_to_ask"]
         assert "white_scoresheet" in result["game_state"]
         assert "black_scoresheet" in result["game_state"]
+
+    def test_serialize_wild16_game(self):
+        game = BerkeleyGame(ruleset=RULESET_WILD16)
+        result = serialize_berkeley_game(game)
+
+        assert result["game_state"]["ruleset_id"] == RULESET_WILD16
+        assert result["game_state"]["any_rule"] is False
     
     def test_serialize_game_with_moves(self):
         game = BerkeleyGame(any_rule=True)
@@ -422,6 +474,22 @@ class TestBerkeleyGameSerializer:
         # Check that scoresheets are preserved
         assert len(deserialized._whites_scoresheet.moves_own) == len(game._whites_scoresheet.moves_own)
         assert len(deserialized._blacks_scoresheet.moves_own) == len(game._blacks_scoresheet.moves_own)
+
+    def test_wild16_roundtrip_preserves_private_illegal_attempts(self):
+        game = BerkeleyGame(ruleset=RULESET_WILD16)
+        game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move.from_uci("e2e5")))
+        game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move.from_uci("e2e4")))
+        serialized = serialize_berkeley_game(game)
+        deserialized = deserialize_berkeley_game(serialized)
+
+        assert deserialized.ruleset_id == RULESET_WILD16
+        assert deserialized._whites_scoresheet.moves_own[0][0][1] == KriegspielAnswer(MainAnnouncement.ILLEGAL_MOVE)
+        assert len(deserialized._blacks_scoresheet.moves_opponent) == 1
+        assert len(deserialized._blacks_scoresheet.moves_opponent[0]) == 1
+        assert deserialized._blacks_scoresheet.moves_opponent[0][0][1] == KriegspielAnswer(
+            MainAnnouncement.REGULAR_MOVE,
+            next_turn_pawn_tries=0,
+        )
 
     def test_deserialize_rejects_missing_move_stack(self):
         game = BerkeleyGame(any_rule=True)


### PR DESCRIPTION
## Summary
- add first-class `wild16` ruleset support to the shared hidden-board engine
- model Wild 16 public metadata in `KriegspielAnswer`, including pawn-vs-piece capture announcements and next-turn pawn-try counts
- keep Wild 16 illegal attempts private to the mover while preserving Berkeley behavior for existing rulesets
- bump the package to `1.3.0`, update release notes, and document Wild 16 in the README

## What changed
- extended the ruleset policy layer so variants can control illegal-attempt classification, visibility, discard behavior, typed capture announcements, and Wild 16 pawn-try announcements
- updated `BerkeleyGame` to expose `current_turn_pawn_tries`, preserve repeatable private illegal attempts for Wild 16, and attach Wild 16 metadata to completed-move answers
- added `CapturedPieceAnnouncement` plus optional `captured_piece_announcement` and `next_turn_pawn_tries` fields on `KriegspielAnswer`
- advanced JSON serialization to schema `5` while keeping schema `3` and `4` readable
- added focused Wild 16 engine and serialization coverage for private illegal attempts, typed captures, and legal pawn-try counting

## Testing
- `source .venv/bin/activate && python -m pytest`
- result: `222 passed`
- coverage: `98.52%` total with branch coverage enabled by default

## Follow-up
- backend and frontend still need separate integration work to surface Wild 16-specific current-message/history behavior in the app