### PR TITLE
Split out Wild 16 entrypoint and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,19 @@ game.save_game("game.json")
 loaded = BerkeleyGame.load_game("game.json")
 ```
 
-Wild 16 uses the same engine with an explicit ruleset:
+Wild 16 now has its own convenience entrypoint:
 
 ```python
-wild16 = BerkeleyGame(ruleset="wild16")
+from kriegspiel.wild16 import Wild16Game
+
+wild16 = Wild16Game()
 print(wild16.current_turn_pawn_tries)
 ```
 
 ## Main Concepts
 
 - `BerkeleyGame`: the referee and full hidden board state
+- `Wild16Game`: Wild 16 convenience entrypoint over the shared hidden-board engine
 - `KriegspielMove`: a player question, either a normal move or `ASK_ANY`
 - `KriegspielAnswer`: the referee response, including move outcome, captures, special announcements, and variant-specific public metadata
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## Kriegspiel v. 1.3.1
+
+- **Wild 16 Entry Point**: added `kriegspiel.wild16.Wild16Game` as a dedicated convenience wrapper over the shared hidden-board engine
+- **Test Organization**: moved Wild 16 engine behavior checks into a dedicated `tests/test_wild16.py` file so Berkeley and Wild 16 coverage are easier to navigate separately
+
 ## Kriegspiel v. 1.3.0
 
 - **Wild 16 Support**: added first-class `wild16` ruleset handling, including typed pawn-vs-piece capture announcements, Wild 16 pawn-try counts, and private illegal-attempt behavior

--- a/kriegspiel/__init__.py
+++ b/kriegspiel/__init__.py
@@ -4,4 +4,4 @@ __author__ = "Alexander Filatov"
 
 __email__ = "alexander@kriegspiel.org"
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/kriegspiel/serialization.py
+++ b/kriegspiel/serialization.py
@@ -9,7 +9,7 @@ Kriegspiel game components using JSON format with custom encoders/decoders.
 JSON Schema Structure:
 {
   "schema_version": 5,
-  "library_version": "1.3.0",
+  "library_version": "1.3.1",
   "game_type": "BerkeleyGame",
   "game_state": {
     "ruleset_id": "berkeley_any",

--- a/kriegspiel/wild16.py
+++ b/kriegspiel/wild16.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+"""Convenience entrypoint for the Wild 16 Kriegspiel ruleset."""
+
+from __future__ import annotations
+
+from kriegspiel.berkeley import BerkeleyGame
+from kriegspiel.move import KriegspielScoresheet as KSSS
+from kriegspiel.rulesets import RULESET_WILD16
+from kriegspiel.serialization import load_game_from_json
+
+
+class Wild16Game(BerkeleyGame):
+    """Wild 16 convenience wrapper over the shared Berkeley-family engine."""
+
+    def __init__(self):
+        super().__init__(ruleset=RULESET_WILD16)
+
+    @classmethod
+    def _from_berkeley_game(cls, game):
+        """Rebuild a Wild16Game wrapper from a validated BerkeleyGame instance."""
+        if not isinstance(game, BerkeleyGame):
+            raise TypeError("game must be a BerkeleyGame")
+        if game.ruleset_id != RULESET_WILD16:
+            raise ValueError("game must use the wild16 ruleset")
+
+        instance = cls()
+        instance._board = game._board.copy(stack=True)
+        instance._must_use_pawns = game._must_use_pawns
+        instance._game_over = game._game_over
+        instance._possible_to_ask = list(game.possible_to_ask)
+        instance._possible_to_ask_set = set(game.possible_to_ask)
+        instance._whites_scoresheet = KSSS.from_snapshot(game._whites_scoresheet.snapshot())
+        instance._blacks_scoresheet = KSSS.from_snapshot(game._blacks_scoresheet.snapshot())
+        return instance
+
+    @classmethod
+    def from_snapshot(cls, snapshot):
+        """Build a Wild16Game from a validated snapshot."""
+        return cls._from_berkeley_game(BerkeleyGame.from_snapshot(snapshot))
+
+    @classmethod
+    def load_game(cls, filename):
+        """Load a Wild 16 game from disk."""
+        return cls._from_berkeley_game(load_game_from_json(filename))

--- a/tests/test_berkeley.py
+++ b/tests/test_berkeley.py
@@ -20,25 +20,12 @@ from kriegspiel.move import KriegspielMove as KSMove
 from kriegspiel.move import QuestionAnnouncement as QA
 
 from kriegspiel.move import KriegspielAnswer as KSAnswer
-from kriegspiel.move import CapturedPieceAnnouncement as CPA
 from kriegspiel.move import MainAnnouncement as MA
 from kriegspiel.move import SpecialCaseAnnouncement as SCA
 from kriegspiel.rulesets import RULESET_BERKELEY
 from kriegspiel.rulesets import RULESET_BERKELEY_ANY
-from kriegspiel.rulesets import RULESET_WILD16
 from kriegspiel.rulesets import resolve_ruleset_policy
 from kriegspiel.snapshot import BerkeleyGameSnapshot
-
-
-def _build_hidden_blocker_wild16_game():
-    game = BerkeleyGame(ruleset=RULESET_WILD16)
-    game._board.clear()
-    game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
-    game._board.set_piece_at(chess.E8, chess.Piece(chess.KING, chess.BLACK))
-    game._board.set_piece_at(chess.C1, chess.Piece(chess.BISHOP, chess.WHITE))
-    game._board.set_piece_at(chess.D2, chess.Piece(chess.KNIGHT, chess.BLACK))
-    game._generate_possible_to_ask_list()
-    return game
 
 
 @pytest.mark.integration
@@ -92,15 +79,6 @@ def test_unknown_ruleset_is_rejected():
         BerkeleyGame(ruleset="unknown_variant")
 
 
-def test_explicit_ruleset_can_enable_wild16():
-    g = BerkeleyGame(ruleset=RULESET_WILD16)
-
-    assert g.ruleset_id == RULESET_WILD16
-    assert g.any_rule is False
-    assert KSMove(QA.ASK_ANY) not in g.possible_to_ask
-    assert g.current_turn_pawn_tries == 0
-
-
 def test_ruleset_policy_returns_none_for_non_special_question():
     policy = resolve_ruleset_policy(ruleset=RULESET_BERKELEY_ANY)
 
@@ -111,82 +89,6 @@ def test_ruleset_policy_rejects_ask_any_when_disabled():
     policy = resolve_ruleset_policy(ruleset=RULESET_BERKELEY)
 
     assert policy.handle_special_question(BerkeleyGame(any_rule=False), KSMove(QA.ASK_ANY)) == KSAnswer(MA.IMPOSSIBLE_TO_ASK)
-
-
-def test_wild16_policy_uses_private_illegal_moves():
-    policy = resolve_ruleset_policy(ruleset=RULESET_WILD16)
-
-    assert policy.classify_impossible_common_attempt() == MA.ILLEGAL_MOVE
-    assert policy.public_illegal_attempts is False
-    assert policy.discard_illegal_attempts is False
-
-
-def test_wild16_illegal_attempt_is_private_to_mover():
-    g = BerkeleyGame(ruleset=RULESET_WILD16)
-
-    result = g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E5)))
-
-    assert result == KSAnswer(MA.ILLEGAL_MOVE)
-    assert len(g._whites_scoresheet.moves_own) == 1
-    assert g._whites_scoresheet.moves_own[0][0][1] == KSAnswer(MA.ILLEGAL_MOVE)
-    assert g._blacks_scoresheet.moves_opponent == []
-
-
-def test_wild16_hidden_illegal_attempt_stays_repeatable():
-    g = _build_hidden_blocker_wild16_game()
-    move = KSMove(QA.COMMON, chess.Move(chess.C1, chess.H6))
-
-    assert move in g.possible_to_ask
-    assert g.ask_for(move) == KSAnswer(MA.ILLEGAL_MOVE)
-    assert g.ask_for(move) == KSAnswer(MA.ILLEGAL_MOVE)
-    assert len(g._whites_scoresheet.moves_own[0]) == 2
-    assert g._blacks_scoresheet.moves_opponent == []
-
-
-def test_wild16_completed_move_announces_next_turn_pawn_tries():
-    g = BerkeleyGame(ruleset=RULESET_WILD16)
-
-    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
-    result = g.ask_for(KSMove(QA.COMMON, chess.Move(chess.D7, chess.D5)))
-
-    assert result == KSAnswer(MA.REGULAR_MOVE, next_turn_pawn_tries=1)
-    assert g.current_turn_pawn_tries == 1
-
-
-def test_wild16_capture_announces_pawn_kind():
-    g = BerkeleyGame(ruleset=RULESET_WILD16)
-    g._board.clear()
-    g._board.set_piece_at(chess.A1, chess.Piece(chess.KING, chess.WHITE))
-    g._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
-    g._board.set_piece_at(chess.E4, chess.Piece(chess.PAWN, chess.WHITE))
-    g._board.set_piece_at(chess.D5, chess.Piece(chess.PAWN, chess.BLACK))
-    g._generate_possible_to_ask_list()
-
-    assert g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E4, chess.D5))) == KSAnswer(
-        MA.CAPTURE_DONE,
-        capture_at_square=chess.D5,
-        captured_piece_announcement=CPA.PAWN,
-        next_turn_pawn_tries=0,
-    )
-
-
-def test_wild16_pawn_try_count_ignores_captures_that_do_not_escape_check():
-    g = BerkeleyGame(ruleset=RULESET_WILD16)
-    g._board.clear()
-    g._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
-    g._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
-    g._board.set_piece_at(chess.D2, chess.Piece(chess.PAWN, chess.WHITE))
-    g._board.set_piece_at(chess.A1, chess.Piece(chess.ROOK, chess.BLACK))
-    g._board.set_piece_at(chess.E3, chess.Piece(chess.BISHOP, chess.BLACK))
-    g._generate_possible_to_ask_list()
-
-    assert g.current_turn_pawn_tries == 0
-
-
-def test_wild16_ask_any_is_not_supported():
-    g = BerkeleyGame(ruleset=RULESET_WILD16)
-
-    assert g.ask_for(KSMove(QA.ASK_ANY)) == KSAnswer(MA.IMPOSSIBLE_TO_ASK)
 
 
 def test_black_illegal_after_any_true():

--- a/tests/test_wild16.py
+++ b/tests/test_wild16.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+
+"""Wild 16-specific engine and convenience entrypoint tests."""
+
+import os
+import tempfile
+
+import pytest
+
+from kriegspiel.berkeley import BerkeleyGame, chess
+from kriegspiel.move import CapturedPieceAnnouncement as CPA
+from kriegspiel.move import KriegspielAnswer as KSAnswer
+from kriegspiel.move import KriegspielMove as KSMove
+from kriegspiel.move import MainAnnouncement as MA
+from kriegspiel.move import QuestionAnnouncement as QA
+from kriegspiel.rulesets import RULESET_WILD16, resolve_ruleset_policy
+from kriegspiel.wild16 import Wild16Game
+
+
+def _build_hidden_blocker_game():
+    game = Wild16Game()
+    game._board.clear()
+    game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.E8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.C1, chess.Piece(chess.BISHOP, chess.WHITE))
+    game._board.set_piece_at(chess.D2, chess.Piece(chess.KNIGHT, chess.BLACK))
+    game._generate_possible_to_ask_list()
+    return game
+
+
+def test_wild16_game_uses_wild16_ruleset():
+    g = Wild16Game()
+
+    assert g.ruleset_id == RULESET_WILD16
+    assert g.any_rule is False
+    assert KSMove(QA.ASK_ANY) not in g.possible_to_ask
+    assert g.current_turn_pawn_tries == 0
+
+
+def test_wild16_policy_uses_private_illegal_moves():
+    policy = resolve_ruleset_policy(ruleset=RULESET_WILD16)
+
+    assert policy.classify_impossible_common_attempt() == MA.ILLEGAL_MOVE
+    assert policy.public_illegal_attempts is False
+    assert policy.discard_illegal_attempts is False
+
+
+def test_wild16_illegal_attempt_is_private_to_mover():
+    g = Wild16Game()
+
+    result = g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E5)))
+
+    assert result == KSAnswer(MA.ILLEGAL_MOVE)
+    assert len(g._whites_scoresheet.moves_own) == 1
+    assert g._whites_scoresheet.moves_own[0][0][1] == KSAnswer(MA.ILLEGAL_MOVE)
+    assert g._blacks_scoresheet.moves_opponent == []
+
+
+def test_wild16_hidden_illegal_attempt_stays_repeatable():
+    g = _build_hidden_blocker_game()
+    move = KSMove(QA.COMMON, chess.Move(chess.C1, chess.H6))
+
+    assert move in g.possible_to_ask
+    assert g.ask_for(move) == KSAnswer(MA.ILLEGAL_MOVE)
+    assert g.ask_for(move) == KSAnswer(MA.ILLEGAL_MOVE)
+    assert len(g._whites_scoresheet.moves_own[0]) == 2
+    assert g._blacks_scoresheet.moves_opponent == []
+
+
+def test_wild16_completed_move_announces_next_turn_pawn_tries():
+    g = Wild16Game()
+
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+    result = g.ask_for(KSMove(QA.COMMON, chess.Move(chess.D7, chess.D5)))
+
+    assert result == KSAnswer(MA.REGULAR_MOVE, next_turn_pawn_tries=1)
+    assert g.current_turn_pawn_tries == 1
+
+
+def test_wild16_capture_announces_pawn_kind():
+    g = Wild16Game()
+    g._board.clear()
+    g._board.set_piece_at(chess.A1, chess.Piece(chess.KING, chess.WHITE))
+    g._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    g._board.set_piece_at(chess.E4, chess.Piece(chess.PAWN, chess.WHITE))
+    g._board.set_piece_at(chess.D5, chess.Piece(chess.PAWN, chess.BLACK))
+    g._generate_possible_to_ask_list()
+
+    assert g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E4, chess.D5))) == KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.D5,
+        captured_piece_announcement=CPA.PAWN,
+        next_turn_pawn_tries=0,
+    )
+
+
+def test_wild16_pawn_try_count_ignores_captures_that_do_not_escape_check():
+    g = Wild16Game()
+    g._board.clear()
+    g._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    g._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    g._board.set_piece_at(chess.D2, chess.Piece(chess.PAWN, chess.WHITE))
+    g._board.set_piece_at(chess.A1, chess.Piece(chess.ROOK, chess.BLACK))
+    g._board.set_piece_at(chess.E3, chess.Piece(chess.BISHOP, chess.BLACK))
+    g._generate_possible_to_ask_list()
+
+    assert g.current_turn_pawn_tries == 0
+
+
+def test_wild16_ask_any_is_not_supported():
+    g = Wild16Game()
+
+    assert g.ask_for(KSMove(QA.ASK_ANY)) == KSAnswer(MA.IMPOSSIBLE_TO_ASK)
+
+
+def test_wild16_from_snapshot_returns_variant_instance():
+    g = Wild16Game()
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+
+    restored = Wild16Game.from_snapshot(g.snapshot())
+
+    assert isinstance(restored, Wild16Game)
+    assert restored.ruleset_id == RULESET_WILD16
+    assert restored._board.fen() == g._board.fen()
+
+
+def test_wild16_from_snapshot_rejects_other_ruleset():
+    g = BerkeleyGame(any_rule=False)
+
+    with pytest.raises(ValueError, match="wild16 ruleset"):
+        Wild16Game.from_snapshot(g.snapshot())
+
+
+def test_wild16_private_helper_rejects_non_game():
+    with pytest.raises(TypeError, match="BerkeleyGame"):
+        Wild16Game._from_berkeley_game("not-a-game")
+
+
+def test_wild16_load_game_returns_variant_instance():
+    g = Wild16Game()
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as handle:
+        filename = handle.name
+
+    try:
+        g.save_game(filename)
+        restored = Wild16Game.load_game(filename)
+    finally:
+        os.unlink(filename)
+
+    assert isinstance(restored, Wild16Game)
+    assert restored.ruleset_id == RULESET_WILD16
+    assert restored._board.fen() == g._board.fen()
+
+
+def test_wild16_load_game_rejects_other_ruleset():
+    g = BerkeleyGame(any_rule=False)
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as handle:
+        filename = handle.name
+
+    try:
+        g.save_game(filename)
+        with pytest.raises(ValueError, match="wild16 ruleset"):
+            Wild16Game.load_game(filename)
+    finally:
+        os.unlink(filename)


### PR DESCRIPTION
## Summary
- add a dedicated `kriegspiel.wild16.Wild16Game` convenience entrypoint
- move Wild 16-specific engine coverage into a new `tests/test_wild16.py`
- keep Berkeley-focused tests in `tests/test_berkeley.py`
- bump the package version to `1.3.1` and update docs/release notes

## Why
The initial Wild 16 support was implemented in the shared engine, which was the right first step, but it left the repo looking more Berkeley-centric than it needed to. This follow-up makes the variant easier to discover and keeps the tests easier to navigate.

## Testing
- `source .venv/bin/activate && python -m pytest -q`
- result: `227 passed`
- coverage: `98.56%` total with branch coverage enabled