### PR TITLE
Add neutral KriegspielGame entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/kriegspiel.svg)](https://pypi.org/project/kriegspiel/)
 
-Python game engine for Berkeley-family Kriegspiel referee rules.
+Python game engine for hidden-information Kriegspiel referee rules.
 
 Current scope:
 - Berkeley Kriegspiel
@@ -22,10 +22,9 @@ pip install kriegspiel
 ```python
 import chess
 
-from kriegspiel.berkeley import BerkeleyGame
-from kriegspiel.move import KriegspielMove, QuestionAnnouncement
+from kriegspiel import KriegspielGame, KriegspielMove, QuestionAnnouncement
 
-game = BerkeleyGame(any_rule=True)
+game = KriegspielGame()
 
 question = KriegspielMove(
     QuestionAnnouncement.COMMON,
@@ -37,13 +36,16 @@ print(answer.main_announcement)
 print(answer.special_announcement)
 
 game.save_game("game.json")
-loaded = BerkeleyGame.load_game("game.json")
+loaded = KriegspielGame.load_game("game.json")
 ```
 
-Wild 16 now has its own convenience entrypoint:
+`KriegspielGame()` defaults to Berkeley + Any for backward compatibility. You can
+still use `BerkeleyGame` explicitly, or pick a ruleset with `ruleset=...`.
+
+Wild 16 also has its own convenience entrypoint:
 
 ```python
-from kriegspiel.wild16 import Wild16Game
+from kriegspiel import Wild16Game
 
 wild16 = Wild16Game()
 print(wild16.current_turn_pawn_tries)
@@ -51,7 +53,8 @@ print(wild16.current_turn_pawn_tries)
 
 ## Main Concepts
 
-- `BerkeleyGame`: the referee and full hidden board state
+- `KriegspielGame`: the neutral public entrypoint for the shared hidden-board engine
+- `BerkeleyGame`: backward-compatible Berkeley-named entrypoint for the same engine
 - `Wild16Game`: Wild 16 convenience entrypoint over the shared hidden-board engine
 - `KriegspielMove`: a player question, either a normal move or `ASK_ANY`
 - `KriegspielAnswer`: the referee response, including move outcome, captures, special announcements, and variant-specific public metadata

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Kriegspiel v. 1.3.2
+
+- **Public API**: added `kriegspiel.game.KriegspielGame` and package-level exports so the shared engine now has a neutral, intuitive entrypoint instead of only Berkeley-named imports
+- **Compatibility**: kept `BerkeleyGame` as a backward-compatible public name and left existing serialized game data compatible
+- **Coverage**: tightened branch coverage around public formatting, ruleset policy edges, shared snapshot helpers, and shared-engine wrapper behavior
+
 ## Kriegspiel v. 1.3.1
 
 - **Wild 16 Entry Point**: added `kriegspiel.wild16.Wild16Game` as a dedicated convenience wrapper over the shared hidden-board engine

--- a/kriegspiel/__init__.py
+++ b/kriegspiel/__init__.py
@@ -4,4 +4,26 @@ __author__ = "Alexander Filatov"
 
 __email__ = "alexander@kriegspiel.org"
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
+
+from kriegspiel.berkeley import BerkeleyGame
+from kriegspiel.game import KriegspielGame
+from kriegspiel.move import CapturedPieceAnnouncement
+from kriegspiel.move import KriegspielAnswer
+from kriegspiel.move import KriegspielMove
+from kriegspiel.move import MainAnnouncement
+from kriegspiel.move import QuestionAnnouncement
+from kriegspiel.move import SpecialCaseAnnouncement
+from kriegspiel.wild16 import Wild16Game
+
+__all__ = [
+    "BerkeleyGame",
+    "CapturedPieceAnnouncement",
+    "KriegspielAnswer",
+    "KriegspielGame",
+    "KriegspielMove",
+    "MainAnnouncement",
+    "QuestionAnnouncement",
+    "SpecialCaseAnnouncement",
+    "Wild16Game",
+]

--- a/kriegspiel/berkeley.py
+++ b/kriegspiel/berkeley.py
@@ -21,13 +21,12 @@ HALFMOVE_CLOCK_LIMIT = 2000
 
 class BerkeleyGame(object):
     """
-    Main class for Berkeley-family Kriegspiel variants.
+    Backward-compatible Berkeley-named entrypoint for the shared engine.
 
     The hidden-board referee engine is shared here, while rule-specific behavior
     such as the Berkeley `ASK_ANY` extension is delegated to a ruleset policy.
-    Today this still ships the classic Berkeley and Berkeley+Any variants, but
-    the policy seam keeps future Cincinnati / Wild 16 support from being wired
-    directly into the engine core.
+    New code can use `KriegspielGame` for a neutral public name, while this
+    class remains stable for Berkeley-focused callers and older integrations.
 
     Communication with this class must be in the form of questions —
     KriegspielMove(s) with QuestionAnnouncement(s).
@@ -247,12 +246,15 @@ class BerkeleyGame(object):
             if self._board.is_insufficient_material():
                 return SCA.DRAW_INSUFFICIENT
             if self._board.is_checkmate():
-                if self._board.result() == "1-0":
+                result = self._board.result()
+                if result == "1-0":
                     return SCA.CHECKMATE_WHITE_WINS
-                elif self._board.result() == "0-1":
+                if result == "0-1":
                     return SCA.CHECKMATE_BLACK_WINS
+                raise RuntimeError("Unexpected checkmate result")  # pragma: no cover
             if self._board.halfmove_clock == HALFMOVE_CLOCK_LIMIT:
                 return SCA.DRAW_TOOMANYREVERSIBLEMOVES
+            raise RuntimeError("Expected a terminal announcement for a finished game")  # pragma: no cover
 
         if self._board.is_check():
             sq = self._board.pieces(chess.KING, self._board.turn)

--- a/kriegspiel/game.py
+++ b/kriegspiel/game.py
@@ -1,31 +1,32 @@
 # -*- coding: utf-8 -*-
 
-"""Convenience entrypoint for the Wild 16 Kriegspiel ruleset."""
+"""Generic public entrypoint for the shared Kriegspiel engine."""
 
 from __future__ import annotations
 
 from kriegspiel.berkeley import BerkeleyGame
-from kriegspiel.game import KriegspielGame
 from kriegspiel.move import KriegspielScoresheet as KSSS
-from kriegspiel.rulesets import RULESET_WILD16
 from kriegspiel.serialization import load_game_from_json
 
 
-class Wild16Game(KriegspielGame):
-    """Wild 16 convenience wrapper over the shared Berkeley-family engine."""
+class KriegspielGame(BerkeleyGame):
+    """Neutral public entrypoint for the shared hidden-board Kriegspiel engine.
 
-    def __init__(self):
-        super().__init__(ruleset=RULESET_WILD16)
+    This class uses the same engine as ``BerkeleyGame`` but exposes it through a
+    generic name that fits multiple rulesets. The historical Berkeley-named
+    class remains available for backward compatibility.
+    """
+
+    def __init__(self, any_rule=None, ruleset=None):
+        super().__init__(any_rule=any_rule, ruleset=ruleset)
 
     @classmethod
     def _from_berkeley_game(cls, game):
-        """Rebuild a Wild16Game wrapper from a validated shared-engine instance."""
+        """Rebuild a KriegspielGame from a validated shared-engine instance."""
         if not isinstance(game, BerkeleyGame):
             raise TypeError("game must be a BerkeleyGame")
-        if game.ruleset_id != RULESET_WILD16:
-            raise ValueError("game must use the wild16 ruleset")
 
-        instance = cls()
+        instance = cls(ruleset=game.ruleset_id)
         instance._board = game._board.copy(stack=True)
         instance._must_use_pawns = game._must_use_pawns
         instance._game_over = game._game_over
@@ -37,10 +38,10 @@ class Wild16Game(KriegspielGame):
 
     @classmethod
     def from_snapshot(cls, snapshot):
-        """Build a Wild16Game from a validated snapshot."""
+        """Build a KriegspielGame from a validated snapshot."""
         return cls._from_berkeley_game(BerkeleyGame.from_snapshot(snapshot))
 
     @classmethod
     def load_game(cls, filename):
-        """Load a Wild 16 game from disk."""
+        """Load a shared-engine Kriegspiel game from disk."""
         return cls._from_berkeley_game(load_game_from_json(filename))

--- a/kriegspiel/serialization.py
+++ b/kriegspiel/serialization.py
@@ -9,7 +9,7 @@ Kriegspiel game components using JSON format with custom encoders/decoders.
 JSON Schema Structure:
 {
   "schema_version": 5,
-  "library_version": "1.3.1",
+  "library_version": "1.3.2",
   "game_type": "BerkeleyGame",
   "game_state": {
     "ruleset_id": "berkeley_any",

--- a/scripts/benchmark_move_generation.py
+++ b/scripts/benchmark_move_generation.py
@@ -15,17 +15,17 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from kriegspiel.berkeley import BerkeleyGame
+from kriegspiel.game import KriegspielGame
 from kriegspiel.move import KriegspielMove as KSMove
 from kriegspiel.move import QuestionAnnouncement as QA
 
 
-def build_initial() -> BerkeleyGame:
-    return BerkeleyGame()
+def build_initial() -> KriegspielGame:
+    return KriegspielGame()
 
 
-def build_midgame() -> BerkeleyGame:
-    game = BerkeleyGame()
+def build_midgame() -> KriegspielGame:
+    game = KriegspielGame()
     opening_moves = [
         (chess.E2, chess.E4), (chess.E7, chess.E5),
         (chess.G1, chess.F3), (chess.B8, chess.C6),
@@ -40,8 +40,8 @@ def build_midgame() -> BerkeleyGame:
     return game
 
 
-def build_hidden_blocker() -> BerkeleyGame:
-    game = BerkeleyGame(any_rule=False)
+def build_hidden_blocker() -> KriegspielGame:
+    game = KriegspielGame(any_rule=False)
     game._board.clear()
     game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
     game._board.set_piece_at(chess.E8, chess.Piece(chess.KING, chess.BLACK))
@@ -51,8 +51,8 @@ def build_hidden_blocker() -> BerkeleyGame:
     return game
 
 
-def build_long_game() -> BerkeleyGame:
-    game = BerkeleyGame()
+def build_long_game() -> KriegspielGame:
+    game = KriegspielGame()
     for _ in range(40):
         game.ask_for(KSMove(QA.COMMON, chess.Move(chess.G1, chess.F3)))
         game.ask_for(KSMove(QA.COMMON, chess.Move(chess.G8, chess.F6)))
@@ -69,7 +69,7 @@ SCENARIOS = {
 }
 
 
-def benchmark(game: BerkeleyGame, iterations: int, rounds: int) -> tuple[list[float], int]:
+def benchmark(game: KriegspielGame, iterations: int, rounds: int) -> tuple[list[float], int]:
     run_times = []
     askable_count = len(game.possible_to_ask)
     for _ in range(rounds):
@@ -83,7 +83,7 @@ def benchmark(game: BerkeleyGame, iterations: int, rounds: int) -> tuple[list[fl
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Benchmark BerkeleyGame move generation")
+    parser = argparse.ArgumentParser(description="Benchmark KriegspielGame move generation")
     parser.add_argument("--scenario", choices=sorted(SCENARIOS), default="initial")
     parser.add_argument("--iterations", type=int, default=2000)
     parser.add_argument("--rounds", type=int, default=5)

--- a/tests/test_berkeley.py
+++ b/tests/test_berkeley.py
@@ -935,6 +935,12 @@ def test_if_berkeley_wo_any():
     assert g.ask_for(KSMove(QA.ASK_ANY)) == KSAnswer(MA.IMPOSSIBLE_TO_ASK)
 
 
+def test_get_captured_piece_returns_none_for_non_capture():
+    g = BerkeleyGame()
+
+    assert g._get_captured_piece(chess.Move.from_uci("e2e4")) is None
+
+
 def test_snapshot_roundtrip_preserves_ruleset_and_questions():
     g = BerkeleyGame(ruleset=RULESET_BERKELEY_ANY)
     g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for the neutral shared-engine public API."""
+
+import os
+import tempfile
+
+import chess
+import pytest
+
+from kriegspiel import BerkeleyGame
+from kriegspiel import KriegspielGame
+from kriegspiel import KriegspielMove as KSMove
+from kriegspiel import MainAnnouncement as MA
+from kriegspiel import QuestionAnnouncement as QA
+from kriegspiel import Wild16Game
+from kriegspiel.rulesets import RULESET_BERKELEY
+from kriegspiel.rulesets import RULESET_BERKELEY_ANY
+from kriegspiel.snapshot import ScoresheetSnapshot
+from kriegspiel.snapshot import move_stack_from_scoresheets
+from kriegspiel.move import KriegspielAnswer as KSAnswer
+
+
+def test_generic_game_defaults_to_berkeley_any():
+    game = KriegspielGame()
+
+    assert game.ruleset_id == RULESET_BERKELEY_ANY
+    assert game.any_rule is True
+
+
+def test_generic_game_from_snapshot_returns_generic_class():
+    game = KriegspielGame(ruleset=RULESET_BERKELEY)
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e2e4")))
+
+    restored = KriegspielGame.from_snapshot(game.snapshot())
+
+    assert isinstance(restored, KriegspielGame)
+    assert restored.__class__ is KriegspielGame
+    assert restored.ruleset_id == RULESET_BERKELEY
+    assert restored._board.fen() == game._board.fen()
+
+
+def test_generic_game_load_game_returns_generic_class():
+    game = KriegspielGame(ruleset=RULESET_BERKELEY)
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e2e4")))
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as handle:
+        filename = handle.name
+
+    try:
+        game.save_game(filename)
+        restored = KriegspielGame.load_game(filename)
+    finally:
+        os.unlink(filename)
+
+    assert isinstance(restored, KriegspielGame)
+    assert restored.__class__ is KriegspielGame
+    assert restored._board.fen() == game._board.fen()
+
+
+def test_generic_game_helper_rejects_non_game():
+    with pytest.raises(TypeError, match="BerkeleyGame"):
+        KriegspielGame._from_berkeley_game("not-a-game")
+
+
+def test_berkeley_name_remains_available():
+    game = BerkeleyGame(any_rule=False)
+
+    assert isinstance(game, BerkeleyGame)
+    assert game.ruleset_id == RULESET_BERKELEY
+
+
+def test_move_stack_from_scoresheets_handles_black_only_turns():
+    black_move = KSMove(QA.COMMON, chess.Move.from_uci("e7e5"))
+    black_answer = KSAnswer(MA.REGULAR_MOVE)
+    white_scoresheet = ScoresheetSnapshot(
+        color=chess.WHITE,
+        moves_own=tuple(),
+        moves_opponent=tuple(),
+        last_move_number=0,
+    )
+    black_scoresheet = ScoresheetSnapshot(
+        color=chess.BLACK,
+        moves_own=(((black_move, black_answer),),),
+        moves_opponent=tuple(),
+        last_move_number=1,
+    )
+
+    assert move_stack_from_scoresheets(white_scoresheet, black_scoresheet) == ("e7e5",)
+
+
+def test_package_root_exports_variant_entrypoints():
+    assert KriegspielGame.__name__ == "KriegspielGame"
+    assert BerkeleyGame.__name__ == "BerkeleyGame"
+    assert Wild16Game.__name__ == "Wild16Game"

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -358,6 +358,20 @@ def test_ksanswer_str_with_double_check_payload():
     )
 
 
+def test_ksanswer_str_with_capture_payload_and_no_double_check():
+    answer = KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.E4,
+        captured_piece_announcement=CPA.PAWN,
+    )
+
+    assert str(answer) == (
+        "<KriegspielAnswer: MainAnnouncement.CAPTURE_DONE, "
+        "capture_at=e4, captured_piece=CapturedPieceAnnouncement.PAWN, "
+        "special_case=SpecialCaseAnnouncement.NONE, next_turn_pawn_tries=None>"
+    )
+
+
 @pytest.mark.unit
 def test_ksss_empty_own_moves():
     a = KSSS(chess.WHITE)

--- a/tests/test_rulesets.py
+++ b/tests/test_rulesets.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+"""Focused policy tests for shared ruleset behavior."""
+
+import chess
+
+from kriegspiel.move import CapturedPieceAnnouncement as CPA
+from kriegspiel.move import KriegspielAnswer as KSAnswer
+from kriegspiel.move import KriegspielMove as KSMove
+from kriegspiel.move import MainAnnouncement as MA
+from kriegspiel.move import QuestionAnnouncement as QA
+from kriegspiel.rulesets import RULESET_BERKELEY
+from kriegspiel.rulesets import RULESET_BERKELEY_ANY
+from kriegspiel.rulesets import RULESET_WILD16
+from kriegspiel.rulesets import resolve_ruleset_policy
+
+
+def test_resolve_ruleset_policy_accepts_matching_any_rule_flags():
+    assert resolve_ruleset_policy(ruleset=RULESET_BERKELEY_ANY, any_rule=True).identifier == RULESET_BERKELEY_ANY
+    assert resolve_ruleset_policy(ruleset=RULESET_BERKELEY, any_rule=False).identifier == RULESET_BERKELEY
+
+
+def test_ruleset_policy_controls_opponent_visibility():
+    public_policy = resolve_ruleset_policy(ruleset=RULESET_BERKELEY_ANY)
+    private_policy = resolve_ruleset_policy(ruleset=RULESET_WILD16)
+    move = KSMove(QA.COMMON, chess.Move.from_uci("e2e4"))
+
+    assert public_policy.should_record_opponent_answer(move, KSAnswer(MA.IMPOSSIBLE_TO_ASK)) is False
+    assert public_policy.should_record_opponent_answer(move, KSAnswer(MA.ILLEGAL_MOVE)) is True
+    assert private_policy.should_record_opponent_answer(move, KSAnswer(MA.ILLEGAL_MOVE)) is False
+    assert private_policy.should_record_opponent_answer(move, KSAnswer(MA.REGULAR_MOVE)) is True
+
+
+def test_ruleset_policy_announces_piece_captures_for_wild16():
+    policy = resolve_ruleset_policy(ruleset=RULESET_WILD16)
+
+    assert policy.captured_piece_announcement_for(None) is None
+    assert policy.captured_piece_announcement_for(chess.Piece(chess.PAWN, chess.WHITE)) == CPA.PAWN
+    assert policy.captured_piece_announcement_for(chess.Piece(chess.ROOK, chess.WHITE)) == CPA.PIECE

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -15,7 +15,7 @@ from kriegspiel.berkeley import BerkeleyGame
 from kriegspiel.serialization import (
     serialize_chess_move, deserialize_chess_move,
     serialize_enum, deserialize_question_announcement, deserialize_main_announcement, 
-    deserialize_special_case_announcement,
+    deserialize_special_case_announcement, deserialize_captured_piece_announcement,
     serialize_kriegspiel_move, deserialize_kriegspiel_move,
     serialize_kriegspiel_answer, deserialize_kriegspiel_answer,
     serialize_kriegspiel_scoresheet, deserialize_kriegspiel_scoresheet,
@@ -82,6 +82,10 @@ class TestEnumSerializer:
     def test_deserialize_special_case_announcement(self):
         assert deserialize_special_case_announcement("NONE") == SpecialCaseAnnouncement.NONE
         assert deserialize_special_case_announcement("CHECK_RANK") == SpecialCaseAnnouncement.CHECK_RANK
+
+    def test_deserialize_captured_piece_announcement_invalid(self):
+        with pytest.raises(MalformedDataError, match="Invalid CapturedPieceAnnouncement"):
+            deserialize_captured_piece_announcement("NOT_A_CAPTURE_KIND")
     
     def test_enum_roundtrip(self):
         enums_to_test = [

--- a/tests/test_wild16.py
+++ b/tests/test_wild16.py
@@ -56,6 +56,17 @@ def test_wild16_illegal_attempt_is_private_to_mover():
     assert g._blacks_scoresheet.moves_opponent == []
 
 
+def test_wild16_black_illegal_attempt_is_private_to_mover():
+    g = Wild16Game()
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+
+    result = g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E7, chess.E2)))
+
+    assert result == KSAnswer(MA.ILLEGAL_MOVE)
+    assert g._blacks_scoresheet.moves_own[0][0][1] == KSAnswer(MA.ILLEGAL_MOVE)
+    assert g._whites_scoresheet.moves_opponent == []
+
+
 def test_wild16_hidden_illegal_attempt_stays_repeatable():
     g = _build_hidden_blocker_game()
     move = KSMove(QA.COMMON, chess.Move(chess.C1, chess.H6))


### PR DESCRIPTION
## Summary
- add a neutral `kriegspiel.game.KriegspielGame` entrypoint and package-level exports so the shared engine no longer reads Berkeley-only by default
- keep `BerkeleyGame` available as a backward-compatible public name and point Wild 16 at the neutral shared-game entrypoint
- refresh docs, benchmark imports, and release notes to use the intuitive API
- tighten targeted tests so the full suite now reaches 100% line and branch coverage

## Testing
- `.venv/bin/python -m pytest -q`
- result: `241 passed`
- coverage: `100.00%` total, including `100%` branch coverage across all package modules

## Notes
- version bumped to `1.3.2` because this adds a new public API entrypoint
- serialized game compatibility remains intact; existing Berkeley-named APIs still work