### PR TITLE
Add Cincinnati ruleset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Python game engine for hidden-information Kriegspiel referee rules.
 Current scope:
 - Berkeley Kriegspiel
 - Berkeley + Any
+- Cincinnati
 - Wild 16
 
 The package models the referee, not a UI. You interact with it by asking questions as `KriegspielMove` objects and reading `KriegspielAnswer` results.
@@ -43,10 +44,13 @@ loaded = KriegspielGame.load_game("game.json")
 still use `BerkeleyGame` explicitly as a compatibility wrapper, or pick a ruleset
 with `ruleset=...`.
 
-Wild 16 also has its own convenience entrypoint:
+Cincinnati and Wild 16 also have their own convenience entrypoints:
 
 ```python
-from kriegspiel import Wild16Game
+from kriegspiel import CincinnatiGame, Wild16Game
+
+cincinnati = CincinnatiGame()
+print(cincinnati.current_turn_has_pawn_capture)
 
 wild16 = Wild16Game()
 print(wild16.current_turn_pawn_tries)
@@ -56,6 +60,7 @@ print(wild16.current_turn_pawn_tries)
 
 - `KriegspielGame`: the neutral public entrypoint for the shared hidden-board engine
 - `BerkeleyGame`: backward-compatible Berkeley-named wrapper over `KriegspielGame`
+- `CincinnatiGame`: Cincinnati convenience entrypoint with public `NONSENSE` and binary pawn-capture announcements
 - `Wild16Game`: Wild 16 convenience entrypoint over the shared hidden-board engine
 - `KriegspielMove`: a player question, either a normal move or `ASK_ANY`
 - `KriegspielAnswer`: the referee response, including move outcome, captures, special announcements, and variant-specific public metadata

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## Kriegspiel v. 1.4.0
+
+- **Cincinnati Support**: added first-class `cincinnati` ruleset handling plus a dedicated `kriegspiel.cincinnati.CincinnatiGame` convenience entrypoint
+- **Referee Announcements**: added explicit `NONSENSE` answers and Cincinnati-style binary pawn-capture announcements for the next player to move
+- **Serialization**: schema `6` now preserves Cincinnati pawn-capture announcement metadata while still reading schemas `3`, `4`, and `5`
+- **Testing**: added focused Cincinnati engine and serialization coverage while keeping the full package at 100% line and branch coverage
+
 ## Kriegspiel v. 1.3.3
 
 - **API Ownership**: moved the shared engine implementation into `kriegspiel.game.KriegspielGame`, with `BerkeleyGame` now acting as the backward-compatible wrapper instead of the other way around

--- a/kriegspiel/__init__.py
+++ b/kriegspiel/__init__.py
@@ -4,9 +4,10 @@ __author__ = "Alexander Filatov"
 
 __email__ = "alexander@kriegspiel.org"
 
-__version__ = "1.3.3"
+__version__ = "1.4.0"
 
 from kriegspiel.berkeley import BerkeleyGame
+from kriegspiel.cincinnati import CincinnatiGame
 from kriegspiel.game import KriegspielGame
 from kriegspiel.move import CapturedPieceAnnouncement
 from kriegspiel.move import KriegspielAnswer
@@ -22,6 +23,7 @@ from kriegspiel.wild16 import Wild16Game
 __all__ = [
     "BerkeleyGame",
     "BerkeleyGameSnapshot",
+    "CincinnatiGame",
     "CapturedPieceAnnouncement",
     "KriegspielAnswer",
     "KriegspielGame",

--- a/kriegspiel/cincinnati.py
+++ b/kriegspiel/cincinnati.py
@@ -1,28 +1,28 @@
 # -*- coding: utf-8 -*-
 
-"""Convenience entrypoint for the Wild 16 Kriegspiel ruleset."""
+"""Convenience entrypoint for the Cincinnati Kriegspiel ruleset."""
 
 from __future__ import annotations
 
 from kriegspiel.game import KriegspielGame
 from kriegspiel.move import KriegspielScoresheet as KSSS
-from kriegspiel.rulesets import RULESET_WILD16
+from kriegspiel.rulesets import RULESET_CINCINNATI
 from kriegspiel.serialization import load_game_from_json
 
 
-class Wild16Game(KriegspielGame):
-    """Wild 16 convenience wrapper over the shared hidden-board engine."""
+class CincinnatiGame(KriegspielGame):
+    """Cincinnati convenience wrapper over the shared hidden-board engine."""
 
     def __init__(self):
-        super().__init__(ruleset=RULESET_WILD16)
+        super().__init__(ruleset=RULESET_CINCINNATI)
 
     @classmethod
     def _from_kriegspiel_game(cls, game):
-        """Rebuild a Wild16Game wrapper from a validated shared-engine instance."""
+        """Rebuild a CincinnatiGame wrapper from a validated shared-engine instance."""
         if not isinstance(game, KriegspielGame):
             raise TypeError("game must be a KriegspielGame")
-        if game.ruleset_id != RULESET_WILD16:
-            raise ValueError("game must use the wild16 ruleset")
+        if game.ruleset_id != RULESET_CINCINNATI:
+            raise ValueError("game must use the cincinnati ruleset")
 
         instance = cls()
         instance._board = game._board.copy(stack=True)
@@ -34,14 +34,12 @@ class Wild16Game(KriegspielGame):
         instance._blacks_scoresheet = KSSS.from_snapshot(game._blacks_scoresheet.snapshot())
         return instance
 
-    _from_berkeley_game = _from_kriegspiel_game
-
     @classmethod
     def from_snapshot(cls, snapshot):
-        """Build a Wild16Game from a validated snapshot."""
+        """Build a CincinnatiGame from a validated snapshot."""
         return cls._from_kriegspiel_game(KriegspielGame.from_snapshot(snapshot))
 
     @classmethod
     def load_game(cls, filename):
-        """Load a Wild 16 game from disk."""
+        """Load a Cincinnati game from disk."""
         return cls._from_kriegspiel_game(load_game_from_json(filename))

--- a/kriegspiel/game.py
+++ b/kriegspiel/game.py
@@ -23,9 +23,10 @@ class KriegspielGame(object):
     """
     Shared hidden-board Kriegspiel referee engine.
 
-    Ruleset-specific behavior such as Berkeley `ASK_ANY` handling or Wild 16
-    pawn-try announcements is delegated to a policy layer. Variant-named
-    wrappers like `BerkeleyGame` and `Wild16Game` build on this class.
+    Ruleset-specific behavior such as Berkeley `ASK_ANY`, Cincinnati binary
+    pawn-capture announcements, or Wild 16 pawn-try counts is delegated to a
+    policy layer. Variant-named wrappers like `BerkeleyGame`, `CincinnatiGame`,
+    and `Wild16Game` build on this class.
 
     Communication with this class must be in the form of questions —
     KriegspielMove(s) with QuestionAnnouncement(s).
@@ -42,7 +43,7 @@ class KriegspielGame(object):
             any_rule: Legacy compatibility flag for Berkeley+Any. When omitted,
                      Berkeley+Any remains the default.
             ruleset: Explicit ruleset identifier. Supported values are
-                     `berkeley`, `berkeley_any`, and `wild16`.
+                     `berkeley`, `berkeley_any`, `cincinnati`, and `wild16`.
         """
         super().__init__()
         self._ruleset = resolve_ruleset_policy(ruleset=ruleset, any_rule=any_rule)
@@ -111,9 +112,12 @@ class KriegspielGame(object):
                 captured_square, captured_piece_announcement = self._make_move(move.chess_move)
                 special_case = self._check_special_cases()
                 next_turn_pawn_tries = self._ruleset.next_turn_pawn_tries(self)
+                next_turn_has_pawn_capture = self._ruleset.next_turn_has_pawn_capture(self)
                 answer_kwargs = {"special_announcement": special_case}
                 if next_turn_pawn_tries is not None:
                     answer_kwargs["next_turn_pawn_tries"] = next_turn_pawn_tries
+                if next_turn_has_pawn_capture is not None:
+                    answer_kwargs["next_turn_has_pawn_capture"] = next_turn_has_pawn_capture
                 if captured_square is not None:
                     # If it was capture
                     answer_kwargs["capture_at_square"] = captured_square
@@ -471,6 +475,16 @@ class KriegspielGame(object):
             int or None: Legal pawn-capture count when the active ruleset announces it.
         """
         return self._ruleset.next_turn_pawn_tries(self)
+
+    @property
+    def current_turn_has_pawn_capture(self):
+        """
+        Get the Cincinnati-style binary pawn-capture announcement for the player to move.
+
+        Returns:
+            bool or None: Pawn-capture availability when the active ruleset announces it.
+        """
+        return self._ruleset.next_turn_has_pawn_capture(self)
 
     @property
     def must_use_pawns(self):

--- a/kriegspiel/move.py
+++ b/kriegspiel/move.py
@@ -159,7 +159,7 @@ class KriegspielMove(object):
 @enum.unique
 class MainAnnouncement(enum.Enum):
     """
-    There are 6 valid options for how to respond to Question Announcement
+    There are 7 valid options for how to respond to Question Announcement
     in the Kriegspiel game.
 
     Four of them are for the Common Question type:
@@ -171,7 +171,9 @@ class MainAnnouncement(enum.Enum):
         but it is unknown to the player who asks. That is new information
         for the players.
     3. REGULAR_MOVE — a move is valid and immediately done. No capture happened.
-    4. REGULAR_MOVE — a move is valid and immediately done. Capture happened.
+    4. CAPTURE_DONE — a move is valid and immediately done. Capture happened.
+    5. NONSENSE — a move is impossible from the player's own information and
+        should already be known to be impossible.
 
     And there are two responses, that are special from ASK_ANY type of
     Question announcement:
@@ -190,6 +192,7 @@ class MainAnnouncement(enum.Enum):
 
     HAS_ANY = 4
     NO_ANY = 5
+    NONSENSE = 6
 
 
 # There are two types of Main Announcements that correspond to MOVE_DONE.
@@ -268,6 +271,8 @@ class KriegspielAnswer(object):
                                     For CHECK_DOUBLE, provide (CHECK_DOUBLE, [check1, check2]).
                 next_turn_pawn_tries (int): Optional Wild 16 style count of legal pawn
                                     captures available for the next player to move.
+                next_turn_has_pawn_capture (bool): Optional Cincinnati-style binary
+                                    pawn-capture announcement for the next player to move.
         
         Raises:
             TypeError: If main_announcement is not a MainAnnouncement enum value,
@@ -289,6 +294,7 @@ class KriegspielAnswer(object):
         self._check_1 = None
         self._check_2 = None
         self._next_turn_pawn_tries = None
+        self._next_turn_has_pawn_capture = None
 
         if main_announcement == MainAnnouncement.CAPTURE_DONE:
             # Validation, that when capture is done, then valid square should
@@ -341,6 +347,15 @@ class KriegspielAnswer(object):
             if next_turn_pawn_tries < 0:
                 raise ValueError("next_turn_pawn_tries must be non-negative")
             self._next_turn_pawn_tries = next_turn_pawn_tries
+
+        if "next_turn_has_pawn_capture" in kwargs:
+            next_turn_has_pawn_capture = kwargs["next_turn_has_pawn_capture"]
+            if not isinstance(next_turn_has_pawn_capture, bool):
+                raise TypeError("next_turn_has_pawn_capture must be a boolean")
+            self._next_turn_has_pawn_capture = next_turn_has_pawn_capture
+
+        if self._next_turn_pawn_tries is not None and self._next_turn_has_pawn_capture is not None:
+            raise ValueError("Use either next_turn_pawn_tries or next_turn_has_pawn_capture, not both")
 
         if self._main_announcement in MOVE_DONE:
             self._move_done = True
@@ -409,6 +424,16 @@ class KriegspielAnswer(object):
         return self._next_turn_pawn_tries
 
     @property
+    def next_turn_has_pawn_capture(self):
+        """
+        Get the next player's binary pawn-capture announcement when the ruleset exposes it.
+
+        Returns:
+            bool or None: Cincinnati-style pawn-capture availability for the next player.
+        """
+        return self._next_turn_has_pawn_capture
+
+    @property
     def check_1(self):
         """
         Get the first check type in a double check situation.
@@ -448,6 +473,8 @@ class KriegspielAnswer(object):
             f"special_case={self._special_announcement}",
             f"next_turn_pawn_tries={self._next_turn_pawn_tries}",
         ]
+        if self._next_turn_has_pawn_capture is not None:
+            main_data.append(f"next_turn_has_pawn_capture={self._next_turn_has_pawn_capture}")
 
         if self._check_1 is not None or self._check_2 is not None:
             extra_data = f"check_1={self._check_1}, check_2={self._check_2}"
@@ -462,6 +489,7 @@ class KriegspielAnswer(object):
             self._captured_piece_announcement,
             self._special_announcement,
             self._next_turn_pawn_tries,
+            self._next_turn_has_pawn_capture,
             self._check_1,
             self._check_2,
         )
@@ -473,6 +501,7 @@ class KriegspielAnswer(object):
             self._captured_piece_announcement.value if self._captured_piece_announcement is not None else -1,
             self._special_announcement.value,
             self._next_turn_pawn_tries if self._next_turn_pawn_tries is not None else -1,
+            -1 if self._next_turn_has_pawn_capture is None else int(self._next_turn_has_pawn_capture),
             self._check_1.value if self._check_1 is not None else -1,
             self._check_2.value if self._check_2 is not None else -1,
         )

--- a/kriegspiel/rulesets.py
+++ b/kriegspiel/rulesets.py
@@ -1,4 +1,4 @@
-"""Ruleset policies for Berkeley-family hidden-information chess."""
+"""Ruleset policies for hidden-information Kriegspiel variants."""
 
 from __future__ import annotations
 
@@ -15,17 +15,18 @@ from kriegspiel.move import QuestionAnnouncement as QA
 
 RULESET_BERKELEY = "berkeley"
 RULESET_BERKELEY_ANY = "berkeley_any"
+RULESET_CINCINNATI = "cincinnati"
 RULESET_WILD16 = "wild16"
 
 
 @dataclass(frozen=True)
 class BerkeleyRulesetPolicy:
-    """Policy layer for Berkeley-family rulesets.
+    """Policy layer for shared Kriegspiel rulesets.
 
     The hidden-board move engine is shared, while this policy decides
     which referee-only questions exist and how those questions constrain
     the next prompt. This keeps the current Berkeley behavior intact while
-    making future Cincinnati / Wild 16 variants easier to add.
+    making Cincinnati / Wild 16 style variants easier to add.
     """
 
     identifier: str
@@ -35,6 +36,7 @@ class BerkeleyRulesetPolicy:
     public_illegal_attempts: bool
     typed_capture_announcements: bool
     announce_next_turn_pawn_tries: bool
+    announce_next_turn_has_pawn_capture: bool
 
     def add_special_questions(self, possibilities: set[KSMove]) -> None:
         if self.allow_ask_any:
@@ -87,6 +89,11 @@ class BerkeleyRulesetPolicy:
             return None
         return game._count_legal_pawn_captures()
 
+    def next_turn_has_pawn_capture(self, game) -> bool | None:
+        if not self.announce_next_turn_has_pawn_capture or game.game_over:
+            return None
+        return game._has_any_pawn_captures()
+
 
 def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None = None) -> BerkeleyRulesetPolicy:
     """Resolve legacy `any_rule` calls into an explicit ruleset policy."""
@@ -109,6 +116,7 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             public_illegal_attempts=True,
             typed_capture_announcements=False,
             announce_next_turn_pawn_tries=False,
+            announce_next_turn_has_pawn_capture=False,
         )
     if ruleset == RULESET_BERKELEY:
         return BerkeleyRulesetPolicy(
@@ -119,6 +127,18 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             public_illegal_attempts=True,
             typed_capture_announcements=False,
             announce_next_turn_pawn_tries=False,
+            announce_next_turn_has_pawn_capture=False,
+        )
+    if ruleset == RULESET_CINCINNATI:
+        return BerkeleyRulesetPolicy(
+            identifier=ruleset,
+            allow_ask_any=False,
+            invalid_common_attempt_result=MA.NONSENSE,
+            discard_illegal_attempts=True,
+            public_illegal_attempts=True,
+            typed_capture_announcements=True,
+            announce_next_turn_pawn_tries=False,
+            announce_next_turn_has_pawn_capture=True,
         )
     if ruleset == RULESET_WILD16:
         return BerkeleyRulesetPolicy(
@@ -129,5 +149,6 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             public_illegal_attempts=False,
             typed_capture_announcements=True,
             announce_next_turn_pawn_tries=True,
+            announce_next_turn_has_pawn_capture=False,
         )
     raise ValueError(f"Unsupported ruleset: {ruleset!r}")

--- a/kriegspiel/serialization.py
+++ b/kriegspiel/serialization.py
@@ -8,8 +8,8 @@ Kriegspiel game components using JSON format with custom encoders/decoders.
 
 JSON Schema Structure:
 {
-  "schema_version": 5,
-  "library_version": "1.3.3",
+  "schema_version": 6,
+  "library_version": "1.4.0",
   "game_type": "BerkeleyGame",
   "game_state": {
     "ruleset_id": "berkeley_any",
@@ -48,6 +48,7 @@ moves_own/moves_opponent: [
         "captured_piece_announcement": "PAWN" | "PIECE" | null,
         "special_announcement": "NONE" | "CHECK_RANK" | ...,
         "next_turn_pawn_tries": int | null,
+        "next_turn_has_pawn_capture": bool | null,
         "check_1": "CHECK_RANK" | null,  // For double check
         "check_2": "CHECK_FILE" | null   // For double check
       }
@@ -74,8 +75,9 @@ from kriegspiel.snapshot import move_stack_from_scoresheets
 from kriegspiel import __version__
 
 LEGACY_SERIALIZATION_SCHEMA_VERSION = 3
-PREVIOUS_SERIALIZATION_SCHEMA_VERSION = 4
-SERIALIZATION_SCHEMA_VERSION = 5
+INTERMEDIATE_SERIALIZATION_SCHEMA_VERSION = 4
+PREVIOUS_SERIALIZATION_SCHEMA_VERSION = 5
+SERIALIZATION_SCHEMA_VERSION = 6
 
 
 class SerializationError(Exception):
@@ -207,7 +209,7 @@ def deserialize_possible_to_ask(data: Any) -> List[KriegspielMove]:
 
 def serialize_kriegspiel_answer(answer: KriegspielAnswer) -> Dict[str, Any]:
     """Serialize KriegspielAnswer to dictionary."""
-    return {
+    result = {
         "main_announcement": serialize_enum(answer.main_announcement),
         "capture_at_square": answer.capture_at_square,
         "captured_piece_announcement": (
@@ -220,6 +222,9 @@ def serialize_kriegspiel_answer(answer: KriegspielAnswer) -> Dict[str, Any]:
         "check_1": serialize_enum(answer.check_1) if answer.check_1 is not None else None,
         "check_2": serialize_enum(answer.check_2) if answer.check_2 is not None else None
     }
+    if answer.next_turn_has_pawn_capture is not None:
+        result["next_turn_has_pawn_capture"] = answer.next_turn_has_pawn_capture
+    return result
 
 
 def deserialize_kriegspiel_answer(data: Dict[str, Any]) -> KriegspielAnswer:
@@ -238,6 +243,8 @@ def deserialize_kriegspiel_answer(data: Dict[str, Any]) -> KriegspielAnswer:
             )
         if data.get("next_turn_pawn_tries") is not None:
             kwargs["next_turn_pawn_tries"] = data["next_turn_pawn_tries"]
+        if data.get("next_turn_has_pawn_capture") is not None:
+            kwargs["next_turn_has_pawn_capture"] = data["next_turn_has_pawn_capture"]
         
         special_announcement = deserialize_special_case_announcement(data["special_announcement"])
         
@@ -335,6 +342,7 @@ def deserialize_berkeley_game(data: Dict[str, Any]):
             raise UnsupportedVersionError("Missing schema_version")
         if schema_version not in {
             LEGACY_SERIALIZATION_SCHEMA_VERSION,
+            INTERMEDIATE_SERIALIZATION_SCHEMA_VERSION,
             PREVIOUS_SERIALIZATION_SCHEMA_VERSION,
             SERIALIZATION_SCHEMA_VERSION,
         }:

--- a/tests/test_cincinnati.py
+++ b/tests/test_cincinnati.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+
+"""Cincinnati-specific engine and convenience entrypoint tests."""
+
+import os
+import tempfile
+
+import pytest
+
+from kriegspiel.berkeley import BerkeleyGame, chess
+from kriegspiel.cincinnati import CincinnatiGame
+from kriegspiel.move import CapturedPieceAnnouncement as CPA
+from kriegspiel.move import KriegspielAnswer as KSAnswer
+from kriegspiel.move import KriegspielMove as KSMove
+from kriegspiel.move import MainAnnouncement as MA
+from kriegspiel.move import QuestionAnnouncement as QA
+from kriegspiel.rulesets import RULESET_CINCINNATI, resolve_ruleset_policy
+
+
+def _build_hidden_blocker_game():
+    game = CincinnatiGame()
+    game._board.clear()
+    game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.E8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.C1, chess.Piece(chess.BISHOP, chess.WHITE))
+    game._board.set_piece_at(chess.D2, chess.Piece(chess.KNIGHT, chess.BLACK))
+    game._generate_possible_to_ask_list()
+    return game
+
+
+def test_cincinnati_game_uses_cincinnati_ruleset():
+    g = CincinnatiGame()
+
+    assert g.ruleset_id == RULESET_CINCINNATI
+    assert g.any_rule is False
+    assert KSMove(QA.ASK_ANY) not in g.possible_to_ask
+    assert g.current_turn_has_pawn_capture is False
+    assert g.current_turn_pawn_tries is None
+
+
+def test_cincinnati_policy_uses_public_nonsense_and_binary_pawn_capture():
+    policy = resolve_ruleset_policy(ruleset=RULESET_CINCINNATI)
+
+    assert policy.classify_impossible_common_attempt() == MA.NONSENSE
+    assert policy.public_illegal_attempts is True
+    assert policy.discard_illegal_attempts is True
+    assert policy.typed_capture_announcements is True
+
+
+def test_cincinnati_illegal_attempt_is_public_to_opponent():
+    g = _build_hidden_blocker_game()
+    move = KSMove(QA.COMMON, chess.Move(chess.C1, chess.H6))
+
+    result = g.ask_for(move)
+
+    assert result == KSAnswer(MA.ILLEGAL_MOVE)
+    assert len(g._whites_scoresheet.moves_own) == 1
+    assert g._whites_scoresheet.moves_own[0][0][1] == KSAnswer(MA.ILLEGAL_MOVE)
+    assert g._blacks_scoresheet.moves_opponent[0][0][1] == KSAnswer(MA.ILLEGAL_MOVE)
+
+
+def test_cincinnati_repeated_hidden_illegal_attempt_becomes_nonsense():
+    g = _build_hidden_blocker_game()
+    move = KSMove(QA.COMMON, chess.Move(chess.C1, chess.H6))
+
+    assert move in g.possible_to_ask
+    assert g.ask_for(move) == KSAnswer(MA.ILLEGAL_MOVE)
+    assert g.ask_for(move) == KSAnswer(MA.NONSENSE)
+    assert len(g._whites_scoresheet.moves_own[0]) == 2
+    assert g._blacks_scoresheet.moves_opponent[0][0][1] == KSAnswer(MA.ILLEGAL_MOVE)
+    assert g._blacks_scoresheet.moves_opponent[0][1][1] == KSAnswer(MA.NONSENSE)
+
+
+def test_cincinnati_impossible_attempt_from_empty_square_is_nonsense():
+    g = CincinnatiGame()
+
+    assert g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E3, chess.E4))) == KSAnswer(MA.NONSENSE)
+
+
+def test_cincinnati_completed_move_announces_binary_pawn_capture():
+    g = CincinnatiGame()
+
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+    result = g.ask_for(KSMove(QA.COMMON, chess.Move(chess.D7, chess.D5)))
+
+    assert result == KSAnswer(MA.REGULAR_MOVE, next_turn_has_pawn_capture=True)
+    assert g.current_turn_has_pawn_capture is True
+
+
+def test_cincinnati_completed_move_can_announce_no_pawn_capture():
+    g = CincinnatiGame()
+
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+    result = g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E7, chess.E5)))
+
+    assert result == KSAnswer(MA.REGULAR_MOVE, next_turn_has_pawn_capture=False)
+    assert g.current_turn_has_pawn_capture is False
+
+
+def test_cincinnati_capture_announces_pawn_kind():
+    g = CincinnatiGame()
+    g._board.clear()
+    g._board.set_piece_at(chess.A1, chess.Piece(chess.KING, chess.WHITE))
+    g._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    g._board.set_piece_at(chess.E4, chess.Piece(chess.PAWN, chess.WHITE))
+    g._board.set_piece_at(chess.D5, chess.Piece(chess.PAWN, chess.BLACK))
+    g._generate_possible_to_ask_list()
+
+    assert g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E4, chess.D5))) == KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.D5,
+        captured_piece_announcement=CPA.PAWN,
+        next_turn_has_pawn_capture=False,
+    )
+
+
+def test_cincinnati_pawn_capture_announcement_ignores_captures_that_do_not_escape_check():
+    g = CincinnatiGame()
+    g._board.clear()
+    g._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    g._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    g._board.set_piece_at(chess.D2, chess.Piece(chess.PAWN, chess.WHITE))
+    g._board.set_piece_at(chess.A1, chess.Piece(chess.ROOK, chess.BLACK))
+    g._board.set_piece_at(chess.E3, chess.Piece(chess.BISHOP, chess.BLACK))
+    g._generate_possible_to_ask_list()
+
+    assert g.current_turn_has_pawn_capture is False
+
+
+def test_cincinnati_ask_any_is_not_supported():
+    g = CincinnatiGame()
+
+    assert g.ask_for(KSMove(QA.ASK_ANY)) == KSAnswer(MA.IMPOSSIBLE_TO_ASK)
+
+
+def test_cincinnati_from_snapshot_returns_variant_instance():
+    g = CincinnatiGame()
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+
+    restored = CincinnatiGame.from_snapshot(g.snapshot())
+
+    assert isinstance(restored, CincinnatiGame)
+    assert restored.ruleset_id == RULESET_CINCINNATI
+    assert restored._board.fen() == g._board.fen()
+
+
+def test_cincinnati_from_snapshot_rejects_other_ruleset():
+    g = BerkeleyGame(any_rule=False)
+
+    with pytest.raises(ValueError, match="cincinnati ruleset"):
+        CincinnatiGame.from_snapshot(g.snapshot())
+
+
+def test_cincinnati_private_helper_rejects_non_game():
+    with pytest.raises(TypeError, match="KriegspielGame"):
+        CincinnatiGame._from_kriegspiel_game("not-a-game")
+
+
+def test_cincinnati_load_game_returns_variant_instance():
+    g = CincinnatiGame()
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as handle:
+        filename = handle.name
+
+    try:
+        g.save_game(filename)
+        restored = CincinnatiGame.load_game(filename)
+    finally:
+        os.unlink(filename)
+
+    assert isinstance(restored, CincinnatiGame)
+    assert restored.ruleset_id == RULESET_CINCINNATI
+    assert restored._board.fen() == g._board.fen()
+
+
+def test_cincinnati_load_game_rejects_other_ruleset():
+    g = BerkeleyGame(any_rule=False)
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as handle:
+        filename = handle.name
+
+    try:
+        g.save_game(filename)
+        with pytest.raises(ValueError, match="cincinnati ruleset"):
+            CincinnatiGame.load_game(filename)
+    finally:
+        os.unlink(filename)

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -9,6 +9,7 @@ import chess
 import pytest
 
 from kriegspiel import BerkeleyGame
+from kriegspiel import CincinnatiGame
 from kriegspiel import KriegspielGame
 from kriegspiel import KriegspielMove as KSMove
 from kriegspiel import MainAnnouncement as MA
@@ -27,6 +28,8 @@ def test_generic_game_defaults_to_berkeley_any():
 
     assert game.ruleset_id == RULESET_BERKELEY_ANY
     assert game.any_rule is True
+    assert game.current_turn_has_pawn_capture is None
+    assert game.current_turn_pawn_tries is None
 
 
 def test_generic_game_from_snapshot_returns_generic_class():
@@ -105,4 +108,5 @@ def test_move_stack_from_scoresheets_handles_black_only_turns():
 def test_package_root_exports_variant_entrypoints():
     assert KriegspielGame.__name__ == "KriegspielGame"
     assert BerkeleyGame.__name__ == "BerkeleyGame"
+    assert CincinnatiGame.__name__ == "CincinnatiGame"
     assert Wild16Game.__name__ == "Wild16Game"

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -243,6 +243,24 @@ def test_next_turn_pawn_tries_validation():
         KSAnswer(MA.REGULAR_MOVE, next_turn_pawn_tries=-1)
 
 
+def test_next_turn_has_pawn_capture_validation():
+    answer = KSAnswer(MA.REGULAR_MOVE, next_turn_has_pawn_capture=True)
+
+    assert answer.next_turn_has_pawn_capture is True
+
+    with pytest.raises(TypeError, match="next_turn_has_pawn_capture must be a boolean"):
+        KSAnswer(MA.REGULAR_MOVE, next_turn_has_pawn_capture="yes")
+
+
+def test_next_turn_pawn_capture_metadata_is_mutually_exclusive():
+    with pytest.raises(ValueError, match="Use either next_turn_pawn_tries or next_turn_has_pawn_capture"):
+        KSAnswer(
+            MA.REGULAR_MOVE,
+            next_turn_pawn_tries=1,
+            next_turn_has_pawn_capture=True,
+        )
+
+
 @pytest.mark.unit
 def test_capture_square_range_validation():
     """Test that capture squares must be within valid range (0-63)."""
@@ -369,6 +387,19 @@ def test_ksanswer_str_with_capture_payload_and_no_double_check():
         "<KriegspielAnswer: MainAnnouncement.CAPTURE_DONE, "
         "capture_at=e4, captured_piece=CapturedPieceAnnouncement.PAWN, "
         "special_case=SpecialCaseAnnouncement.NONE, next_turn_pawn_tries=None>"
+    )
+
+
+def test_ksanswer_str_with_cincinnati_pawn_capture_payload():
+    answer = KSAnswer(
+        MA.REGULAR_MOVE,
+        next_turn_has_pawn_capture=True,
+    )
+
+    assert str(answer) == (
+        "<KriegspielAnswer: MainAnnouncement.REGULAR_MOVE, "
+        "capture_at=None, captured_piece=None, special_case=SpecialCaseAnnouncement.NONE, "
+        "next_turn_pawn_tries=None, next_turn_has_pawn_capture=True>"
     )
 
 

--- a/tests/test_rulesets.py
+++ b/tests/test_rulesets.py
@@ -11,6 +11,7 @@ from kriegspiel.move import MainAnnouncement as MA
 from kriegspiel.move import QuestionAnnouncement as QA
 from kriegspiel.rulesets import RULESET_BERKELEY
 from kriegspiel.rulesets import RULESET_BERKELEY_ANY
+from kriegspiel.rulesets import RULESET_CINCINNATI
 from kriegspiel.rulesets import RULESET_WILD16
 from kriegspiel.rulesets import resolve_ruleset_policy
 
@@ -18,6 +19,7 @@ from kriegspiel.rulesets import resolve_ruleset_policy
 def test_resolve_ruleset_policy_accepts_matching_any_rule_flags():
     assert resolve_ruleset_policy(ruleset=RULESET_BERKELEY_ANY, any_rule=True).identifier == RULESET_BERKELEY_ANY
     assert resolve_ruleset_policy(ruleset=RULESET_BERKELEY, any_rule=False).identifier == RULESET_BERKELEY
+    assert resolve_ruleset_policy(ruleset=RULESET_CINCINNATI, any_rule=False).identifier == RULESET_CINCINNATI
 
 
 def test_ruleset_policy_controls_opponent_visibility():
@@ -37,3 +39,11 @@ def test_ruleset_policy_announces_piece_captures_for_wild16():
     assert policy.captured_piece_announcement_for(None) is None
     assert policy.captured_piece_announcement_for(chess.Piece(chess.PAWN, chess.WHITE)) == CPA.PAWN
     assert policy.captured_piece_announcement_for(chess.Piece(chess.ROOK, chess.WHITE)) == CPA.PIECE
+
+
+def test_ruleset_policy_announces_binary_pawn_capture_for_cincinnati():
+    policy = resolve_ruleset_policy(ruleset=RULESET_CINCINNATI)
+    fake_game = type("FakeGame", (), {"game_over": False, "_has_any_pawn_captures": lambda self: True})()
+
+    assert policy.next_turn_has_pawn_capture(fake_game) is True
+    assert policy.next_turn_pawn_tries(fake_game) is None

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -27,6 +27,7 @@ from kriegspiel.serialization import (
 )
 from kriegspiel.rulesets import RULESET_BERKELEY
 from kriegspiel.rulesets import RULESET_BERKELEY_ANY
+from kriegspiel.rulesets import RULESET_CINCINNATI
 from kriegspiel.rulesets import RULESET_WILD16
 
 
@@ -95,6 +96,7 @@ class TestEnumSerializer:
             (MainAnnouncement.REGULAR_MOVE, deserialize_main_announcement),
             (MainAnnouncement.CAPTURE_DONE, deserialize_main_announcement),
             (MainAnnouncement.ILLEGAL_MOVE, deserialize_main_announcement),
+            (MainAnnouncement.NONSENSE, deserialize_main_announcement),
             (SpecialCaseAnnouncement.NONE, deserialize_special_case_announcement),
             (SpecialCaseAnnouncement.CHECK_RANK, deserialize_special_case_announcement),
             (SpecialCaseAnnouncement.CHECKMATE_WHITE_WINS, deserialize_special_case_announcement),
@@ -295,12 +297,47 @@ class TestKriegspielAnswerSerializer:
             captured_piece_announcement=CapturedPieceAnnouncement.PIECE,
             next_turn_pawn_tries=3,
         )
+
+    def test_serialize_cincinnati_answer_fields(self):
+        answer = KriegspielAnswer(
+            MainAnnouncement.REGULAR_MOVE,
+            next_turn_has_pawn_capture=True,
+        )
+
+        assert serialize_kriegspiel_answer(answer) == {
+            "main_announcement": "REGULAR_MOVE",
+            "capture_at_square": None,
+            "captured_piece_announcement": None,
+            "special_announcement": "NONE",
+            "next_turn_pawn_tries": None,
+            "check_1": None,
+            "check_2": None,
+            "next_turn_has_pawn_capture": True,
+        }
+
+    def test_deserialize_cincinnati_answer_fields(self):
+        data = {
+            "main_announcement": "REGULAR_MOVE",
+            "capture_at_square": None,
+            "captured_piece_announcement": None,
+            "special_announcement": "NONE",
+            "next_turn_pawn_tries": None,
+            "check_1": None,
+            "check_2": None,
+            "next_turn_has_pawn_capture": False,
+        }
+
+        assert deserialize_kriegspiel_answer(data) == KriegspielAnswer(
+            MainAnnouncement.REGULAR_MOVE,
+            next_turn_has_pawn_capture=False,
+        )
     
     def test_kriegspiel_answer_roundtrip(self):
         answers = [
             KriegspielAnswer(MainAnnouncement.REGULAR_MOVE),
             KriegspielAnswer(MainAnnouncement.CAPTURE_DONE, capture_at_square=28),
             KriegspielAnswer(MainAnnouncement.ILLEGAL_MOVE),
+            KriegspielAnswer(MainAnnouncement.NONSENSE),
             KriegspielAnswer(MainAnnouncement.REGULAR_MOVE, 
                            special_announcement=SpecialCaseAnnouncement.CHECK_RANK),
             KriegspielAnswer(MainAnnouncement.REGULAR_MOVE,
@@ -309,6 +346,7 @@ class TestKriegspielAnswerSerializer:
                                                 SpecialCaseAnnouncement.CHECK_FILE])),
             KriegspielAnswer(MainAnnouncement.HAS_ANY),
             KriegspielAnswer(MainAnnouncement.NO_ANY),
+            KriegspielAnswer(MainAnnouncement.REGULAR_MOVE, next_turn_has_pawn_capture=True),
         ]
         
         for answer in answers:
@@ -411,6 +449,13 @@ class TestBerkeleyGameSerializer:
 
         assert result["game_state"]["ruleset_id"] == RULESET_WILD16
         assert result["game_state"]["any_rule"] is False
+
+    def test_serialize_cincinnati_game(self):
+        game = BerkeleyGame(ruleset=RULESET_CINCINNATI)
+        result = serialize_berkeley_game(game)
+
+        assert result["game_state"]["ruleset_id"] == RULESET_CINCINNATI
+        assert result["game_state"]["any_rule"] is False
     
     def test_serialize_game_with_moves(self):
         game = BerkeleyGame(any_rule=True)
@@ -494,6 +539,21 @@ class TestBerkeleyGameSerializer:
         assert deserialized._blacks_scoresheet.moves_opponent[0][0][1] == KriegspielAnswer(
             MainAnnouncement.REGULAR_MOVE,
             next_turn_pawn_tries=0,
+        )
+
+    def test_cincinnati_roundtrip_preserves_public_nonsense_and_binary_pawn_capture(self):
+        game = BerkeleyGame(ruleset=RULESET_CINCINNATI)
+        game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move.from_uci("e3e4")))
+        game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move.from_uci("e2e4")))
+        game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move.from_uci("d7d5")))
+        serialized = serialize_berkeley_game(game)
+        deserialized = deserialize_berkeley_game(serialized)
+
+        assert deserialized.ruleset_id == RULESET_CINCINNATI
+        assert deserialized._whites_scoresheet.moves_own[0][0][1] == KriegspielAnswer(MainAnnouncement.NONSENSE)
+        assert deserialized._whites_scoresheet.moves_opponent[0][0][1] == KriegspielAnswer(
+            MainAnnouncement.REGULAR_MOVE,
+            next_turn_has_pawn_capture=True,
         )
 
     def test_deserialize_rejects_missing_move_stack(self):


### PR DESCRIPTION
## Summary
- add first-class `cincinnati` ruleset support plus a dedicated `kriegspiel.cincinnati.CincinnatiGame` convenience entrypoint
- add explicit `MainAnnouncement.NONSENSE` and Cincinnati-style binary pawn-capture announcement metadata for the next player to move
- preserve typed pawn-vs-piece capture announcements for Cincinnati and bump serialization to schema `6` so the new metadata survives save/load
- update docs, exports, and focused variant coverage while keeping full-package line and branch coverage at 100%

## Behavior
- Cincinnati does not use `ASK_ANY`; pawn-capture availability is announced automatically after each legal move
- hidden-board illegal attempts remain public as `ILLEGAL_MOVE`
- impossible or already-known repeated tries become `NONSENSE`
- captures announce both the square and whether the captured material was a pawn or a piece

## Testing
- `.venv/bin/python -m pytest -q`
- result: `268 passed`
- coverage: `100.00%` total, including `100%` branch coverage across all package modules

## Notes
- version bumped to `1.4.0` because this adds a new ruleset, new public wrapper, and new serialized answer metadata
- schema `6` still reads existing schemas `3`, `4`, and `5`