### PR TITLE
Isolate pawn-capture tries by ruleset

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Kriegspiel v. 1.4.1
+
+- **Ruleset Isolation**: Cincinnati and Wild 16 no longer expose hidden pawn-capture tries when their automatic pawn-capture announcement says none are available
+- **Safety**: `ASK_ANY` post-answer constraints are now scoped to Berkeley+Any only, preventing Berkeley-specific state from affecting other rulesets
+- **Testing**: added regression coverage for cross-ruleset action leakage around `ASK_ANY`, Cincinnati binary pawn captures, and Wild 16 pawn-try counts
+
 ## Kriegspiel v. 1.4.0
 
 - **Cincinnati Support**: added first-class `cincinnati` ruleset handling plus a dedicated `kriegspiel.cincinnati.CincinnatiGame` convenience entrypoint

--- a/kriegspiel/__init__.py
+++ b/kriegspiel/__init__.py
@@ -4,7 +4,7 @@ __author__ = "Alexander Filatov"
 
 __email__ = "alexander@kriegspiel.org"
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 from kriegspiel.berkeley import BerkeleyGame
 from kriegspiel.cincinnati import CincinnatiGame

--- a/kriegspiel/game.py
+++ b/kriegspiel/game.py
@@ -430,7 +430,8 @@ class KriegspielGame(object):
         possibilities = {KSMove(QA.COMMON, chess_move) for chess_move in players_board.legal_moves}
         self._ruleset.add_special_questions(possibilities)
         # Second add possible pawn captures
-        possibilities.update(self._generate_possible_pawn_captures())
+        if self._ruleset.include_pawn_capture_attempts(self):
+            possibilities.update(self._generate_possible_pawn_captures())
         self._set_possible_to_ask(possibilities)
 
     @property

--- a/kriegspiel/rulesets.py
+++ b/kriegspiel/rulesets.py
@@ -42,6 +42,14 @@ class BerkeleyRulesetPolicy:
         if self.allow_ask_any:
             possibilities.add(KSMove(QA.ASK_ANY))
 
+    def include_pawn_capture_attempts(self, game) -> bool:
+        """Return whether hidden pawn-capture tries belong in this prompt."""
+        if self.announce_next_turn_has_pawn_capture:
+            return game._has_any_pawn_captures()
+        if self.announce_next_turn_pawn_tries:
+            return game._count_legal_pawn_captures() > 0
+        return True
+
     def classify_impossible_common_attempt(self) -> MA:
         return self.invalid_common_attempt_result
 
@@ -56,6 +64,8 @@ class BerkeleyRulesetPolicy:
         return KSAnswer(MA.NO_ANY)
 
     def apply_post_answer_constraints(self, game, answer: KSAnswer) -> None:
+        if not self.allow_ask_any:
+            return
         if answer.main_announcement == MA.HAS_ANY:
             pawn_captures = set(game._generate_possible_pawn_captures())
             game._set_possible_to_ask(game._possible_to_ask_set & pawn_captures)

--- a/tests/test_cincinnati.py
+++ b/tests/test_cincinnati.py
@@ -97,6 +97,34 @@ def test_cincinnati_completed_move_can_announce_no_pawn_capture():
     assert g.current_turn_has_pawn_capture is False
 
 
+def test_cincinnati_no_pawn_capture_announcement_blocks_pawn_capture_tries():
+    g = CincinnatiGame()
+
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E7, chess.E5)))
+    left_try = KSMove(QA.COMMON, chess.Move(chess.E4, chess.D5))
+    right_try = KSMove(QA.COMMON, chess.Move(chess.E4, chess.F5))
+
+    assert g.current_turn_has_pawn_capture is False
+    assert left_try not in g.possible_to_ask
+    assert right_try not in g.possible_to_ask
+    assert g.ask_for(left_try) == KSAnswer(MA.NONSENSE)
+
+
+def test_cincinnati_has_pawn_capture_announcement_allows_non_matching_pawn_tries():
+    g = CincinnatiGame()
+
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.D7, chess.D5)))
+    legal_try = KSMove(QA.COMMON, chess.Move(chess.E4, chess.D5))
+    hidden_empty_try = KSMove(QA.COMMON, chess.Move(chess.E4, chess.F5))
+
+    assert g.current_turn_has_pawn_capture is True
+    assert legal_try in g.possible_to_ask
+    assert hidden_empty_try in g.possible_to_ask
+    assert g.ask_for(hidden_empty_try) == KSAnswer(MA.ILLEGAL_MOVE)
+
+
 def test_cincinnati_capture_announces_pawn_kind():
     g = CincinnatiGame()
     g._board.clear()

--- a/tests/test_rules_comparison.py
+++ b/tests/test_rules_comparison.py
@@ -35,6 +35,10 @@ def _left_pawn_capture_move():
     return KSMove(QA.COMMON, chess.Move(chess.E4, chess.D5))
 
 
+def _right_pawn_capture_move():
+    return KSMove(QA.COMMON, chess.Move(chess.E4, chess.F5))
+
+
 @pytest.mark.rules
 def test_rules_comparison_position_announces_binary_vs_counted_pawn_captures():
     berkeley_any = _build_rules_comparison_game(BerkeleyGame())
@@ -107,3 +111,52 @@ def test_rules_comparison_berkeley_any_has_any_forces_a_pawn_capture():
     assert game.must_use_pawns is True
     assert game.ask_for(_piece_capture_move()) == KSAnswer(MA.IMPOSSIBLE_TO_ASK)
     assert game.ask_for(_left_pawn_capture_move()) == KSAnswer(MA.CAPTURE_DONE, capture_at_square=chess.D5)
+
+
+@pytest.mark.rules
+@pytest.mark.parametrize(
+    "game",
+    [
+        pytest.param(BerkeleyGame(), id="berkeley-any"),
+        pytest.param(BerkeleyGame(any_rule=False), id="berkeley"),
+    ],
+)
+def test_rules_comparison_berkeley_family_can_try_pawn_captures_without_announcement(game):
+    game = _build_rules_comparison_game(game)
+
+    assert _left_pawn_capture_move() in game.possible_to_ask
+    assert _right_pawn_capture_move() in game.possible_to_ask
+
+
+@pytest.mark.rules
+@pytest.mark.parametrize(
+    ("game", "expected"),
+    [
+        pytest.param(
+            CincinnatiGame(),
+            KSAnswer(
+                MA.CAPTURE_DONE,
+                capture_at_square=chess.D5,
+                captured_piece_announcement=CPA.PIECE,
+                next_turn_has_pawn_capture=False,
+            ),
+            id="cincinnati",
+        ),
+        pytest.param(
+            Wild16Game(),
+            KSAnswer(
+                MA.CAPTURE_DONE,
+                capture_at_square=chess.D5,
+                captured_piece_announcement=CPA.PIECE,
+                next_turn_pawn_tries=0,
+            ),
+            id="wild16",
+        ),
+    ],
+)
+def test_rules_comparison_automatic_pawn_capture_announcement_allows_pawn_tries(game, expected):
+    game = _build_rules_comparison_game(game)
+
+    assert _left_pawn_capture_move() in game.possible_to_ask
+    assert _right_pawn_capture_move() in game.possible_to_ask
+    assert game.ask_for(_left_pawn_capture_move()) == expected

--- a/tests/test_wild16.py
+++ b/tests/test_wild16.py
@@ -88,6 +88,36 @@ def test_wild16_completed_move_announces_next_turn_pawn_tries():
     assert g.current_turn_pawn_tries == 1
 
 
+def test_wild16_zero_pawn_tries_blocks_pawn_capture_attempts():
+    g = Wild16Game()
+
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E7, chess.E5)))
+    left_try = KSMove(QA.COMMON, chess.Move(chess.E4, chess.D5))
+    right_try = KSMove(QA.COMMON, chess.Move(chess.E4, chess.F5))
+
+    assert g.current_turn_pawn_tries == 0
+    assert left_try not in g.possible_to_ask
+    assert right_try not in g.possible_to_ask
+    assert g.ask_for(left_try) == KSAnswer(MA.ILLEGAL_MOVE)
+    assert len(g._blacks_scoresheet.moves_opponent) == 1
+
+
+def test_wild16_positive_pawn_tries_allow_hidden_pawn_capture_attempts():
+    g = Wild16Game()
+
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+    g.ask_for(KSMove(QA.COMMON, chess.Move(chess.D7, chess.D5)))
+    legal_try = KSMove(QA.COMMON, chess.Move(chess.E4, chess.D5))
+    hidden_empty_try = KSMove(QA.COMMON, chess.Move(chess.E4, chess.F5))
+
+    assert g.current_turn_pawn_tries == 1
+    assert legal_try in g.possible_to_ask
+    assert hidden_empty_try in g.possible_to_ask
+    assert g.ask_for(hidden_empty_try) == KSAnswer(MA.ILLEGAL_MOVE)
+    assert hidden_empty_try in g.possible_to_ask
+
+
 def test_wild16_capture_announces_pawn_kind():
     g = Wild16Game()
     g._board.clear()


### PR DESCRIPTION
## Summary
- block Cincinnati and Wild 16 hidden pawn-capture tries when their automatic announcement says no pawn captures are available
- keep Berkeley/Berkeley+Any pawn-capture try behavior unchanged
- scope Berkeley+Any ASK_ANY post-answer constraints to ASK_ANY-enabled rulesets only
- bump package version to 1.4.1

## Tests
- .venv/bin/python -m pytest (282 passed, 100% line/branch coverage)