### PR TITLE
Count Wild16 promotion captures as one pawn try

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Kriegspiel v. 1.4.3
+
+- **Wild 16 Pawn Tries**: promotion captures now count as one pawn try per capture square instead of one per promotion piece choice.
+
 ## Kriegspiel v. 1.4.2
 
 - **Wild 16 Attempts**: failed illegal attempts are now removed from the current askable move list while remaining private from the opponent.

--- a/kriegspiel/__init__.py
+++ b/kriegspiel/__init__.py
@@ -4,7 +4,7 @@ __author__ = "Alexander Filatov"
 
 __email__ = "alexander@kriegspiel.org"
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 
 from kriegspiel.berkeley import BerkeleyGame
 from kriegspiel.cincinnati import CincinnatiGame

--- a/kriegspiel/game.py
+++ b/kriegspiel/game.py
@@ -321,8 +321,13 @@ class KriegspielGame(object):
         ]
 
     def _count_legal_pawn_captures(self):
-        """Count legal pawn captures for the active player in the true position."""
-        return len(self._legal_pawn_capture_moves())
+        """Count distinct legal pawn-capture attempts in the true position."""
+        return len(
+            {
+                (move.from_square, move.to_square)
+                for move in self._legal_pawn_capture_moves()
+            }
+        )
 
     def _has_any_pawn_captures(self):
         """

--- a/tests/test_wild16.py
+++ b/tests/test_wild16.py
@@ -152,7 +152,7 @@ def test_wild16_pawn_try_count_ignores_captures_that_do_not_escape_check():
 def test_wild16_pawn_try_count_collapses_promotion_choices_to_one_try():
     g = Wild16Game()
     g._board.clear()
-    g._board.set_piece_at(chess.F1, chess.Piece(chess.KING, chess.WHITE))
+    g._board.set_piece_at(chess.F3, chess.Piece(chess.KING, chess.WHITE))
     g._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
     g._board.set_piece_at(chess.D2, chess.Piece(chess.PAWN, chess.BLACK))
     g._board.set_piece_at(chess.C1, chess.Piece(chess.BISHOP, chess.WHITE))

--- a/tests/test_wild16.py
+++ b/tests/test_wild16.py
@@ -149,6 +149,31 @@ def test_wild16_pawn_try_count_ignores_captures_that_do_not_escape_check():
     assert g.current_turn_pawn_tries == 0
 
 
+def test_wild16_pawn_try_count_collapses_promotion_choices_to_one_try():
+    g = Wild16Game()
+    g._board.clear()
+    g._board.set_piece_at(chess.F1, chess.Piece(chess.KING, chess.WHITE))
+    g._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    g._board.set_piece_at(chess.D2, chess.Piece(chess.PAWN, chess.BLACK))
+    g._board.set_piece_at(chess.C1, chess.Piece(chess.BISHOP, chess.WHITE))
+    g._board.turn = chess.BLACK
+    g._generate_possible_to_ask_list()
+
+    promotion_captures = {
+        KSMove(QA.COMMON, chess.Move(chess.D2, chess.C1, promotion=promotion))
+        for promotion in (chess.QUEEN, chess.ROOK, chess.BISHOP, chess.KNIGHT)
+    }
+
+    assert promotion_captures <= set(g.possible_to_ask)
+    assert g.current_turn_pawn_tries == 1
+    assert g.ask_for(KSMove(QA.COMMON, chess.Move(chess.D2, chess.C1, promotion=chess.QUEEN))) == KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.C1,
+        captured_piece_announcement=CPA.PIECE,
+        next_turn_pawn_tries=0,
+    )
+
+
 def test_wild16_ask_any_is_not_supported():
     g = Wild16Game()
 


### PR DESCRIPTION
## Summary
- Change Wild16 pawn-try announcements to count distinct pawn-capture attempts by source and destination square.
- Keep all promotion capture choices legal and askable, so players can still choose queen/rook/bishop/knight.
- Add regression coverage for a `d2xc1=Q/R/B/N` position counting as one pawn try.
- Bump package version to `1.4.3`.

## Testing
- Pending remote validation on `rpis02-cf`.

## Deployment notes
- Backend must bump its `kriegspiel` git dependency after this merges, then restart `ks-backend.service`.