### PR TITLE
[codex] Add engine material summary

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Kriegspiel v. 1.4.4
+
+- **Public Material Summary**: added an engine-owned material summary derived from completed public capture announcements, with ruleset-specific pawn-capture counts for Cincinnati and Wild 16.
+
 ## Kriegspiel v. 1.4.3
 
 - **Wild 16 Pawn Tries**: promotion captures now count as one pawn try per capture square instead of one per promotion piece choice.

--- a/kriegspiel/__init__.py
+++ b/kriegspiel/__init__.py
@@ -4,7 +4,7 @@ __author__ = "Alexander Filatov"
 
 __email__ = "alexander@kriegspiel.org"
 
-__version__ = "1.4.3"
+__version__ = "1.4.4"
 
 from kriegspiel.berkeley import BerkeleyGame
 from kriegspiel.cincinnati import CincinnatiGame
@@ -17,6 +17,8 @@ from kriegspiel.move import QuestionAnnouncement
 from kriegspiel.move import SpecialCaseAnnouncement
 from kriegspiel.snapshot import BerkeleyGameSnapshot
 from kriegspiel.snapshot import KriegspielGameSnapshot
+from kriegspiel.snapshot import MaterialSideSummary
+from kriegspiel.snapshot import PublicMaterialSummary
 from kriegspiel.snapshot import ScoresheetSnapshot
 from kriegspiel.wild16 import Wild16Game
 
@@ -30,6 +32,8 @@ __all__ = [
     "KriegspielGameSnapshot",
     "KriegspielMove",
     "MainAnnouncement",
+    "MaterialSideSummary",
+    "PublicMaterialSummary",
     "QuestionAnnouncement",
     "ScoresheetSnapshot",
     "SpecialCaseAnnouncement",

--- a/kriegspiel/game.py
+++ b/kriegspiel/game.py
@@ -5,6 +5,7 @@ import chess
 from kriegspiel.move import KriegspielMove as KSMove
 from kriegspiel.move import QuestionAnnouncement as QA
 
+from kriegspiel.move import CapturedPieceAnnouncement as CPA
 from kriegspiel.move import KriegspielAnswer as KSAnswer
 from kriegspiel.move import MainAnnouncement as MA
 from kriegspiel.move import SpecialCaseAnnouncement as SCA
@@ -12,6 +13,8 @@ from kriegspiel.move import SpecialCaseAnnouncement as SCA
 from kriegspiel.move import KriegspielScoresheet as KSSS
 from kriegspiel.rulesets import resolve_ruleset_policy
 from kriegspiel.snapshot import KriegspielGameSnapshot
+from kriegspiel.snapshot import MaterialSideSummary
+from kriegspiel.snapshot import PublicMaterialSummary
 from kriegspiel.snapshot import move_stack_from_scoresheets
 from kriegspiel.serialization import save_game_to_json, load_game_from_json
 
@@ -491,6 +494,49 @@ class KriegspielGame(object):
             bool or None: Pawn-capture availability when the active ruleset announces it.
         """
         return self._ruleset.next_turn_has_pawn_capture(self)
+
+    @staticmethod
+    def _capture_counts_from_completed_moves(moves_own):
+        captures = 0
+        pawn_captures = 0
+        for turn in moves_own:
+            for _move, answer in turn:
+                if answer.main_announcement != MA.CAPTURE_DONE:
+                    continue
+                captures += 1
+                if answer.captured_piece_announcement == CPA.PAWN:
+                    pawn_captures += 1
+        return captures, pawn_captures
+
+    @property
+    def public_material_summary(self):
+        """
+        Return material information that is public under the active ruleset.
+
+        Total captures are public in all supported rulesets. Cincinnati and
+        Wild 16 additionally announce whether the captured man was a pawn, so
+        pawn-capture counts are exposed there. The summary is derived from
+        completed capture answers instead of true-board pawn counts, because
+        promotion is intentionally silent in those rulesets.
+        """
+        white_captures, white_pawn_captures = self._capture_counts_from_completed_moves(
+            self._whites_scoresheet.moves_own
+        )
+        black_captures, black_pawn_captures = self._capture_counts_from_completed_moves(
+            self._blacks_scoresheet.moves_own
+        )
+        announces_pawn_captures = self._ruleset.typed_capture_announcements
+
+        return PublicMaterialSummary(
+            white=MaterialSideSummary(
+                pieces_remaining=max(0, 16 - black_captures),
+                pawns_captured=black_pawn_captures if announces_pawn_captures else None,
+            ),
+            black=MaterialSideSummary(
+                pieces_remaining=max(0, 16 - white_captures),
+                pawns_captured=white_pawn_captures if announces_pawn_captures else None,
+            ),
+        )
 
     @property
     def must_use_pawns(self):

--- a/kriegspiel/snapshot.py
+++ b/kriegspiel/snapshot.py
@@ -28,6 +28,22 @@ class ScoresheetSnapshot:
 
 
 @dataclass(frozen=True)
+class MaterialSideSummary:
+    """Public material status for one color."""
+
+    pieces_remaining: int
+    pawns_captured: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class PublicMaterialSummary:
+    """Public material status derived from referee announcements."""
+
+    white: MaterialSideSummary
+    black: MaterialSideSummary
+
+
+@dataclass(frozen=True)
 class KriegspielGameSnapshot:
     """Serializable, public view of a hidden-board Kriegspiel game."""
 

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -13,14 +13,17 @@ from kriegspiel import CincinnatiGame
 from kriegspiel import KriegspielGame
 from kriegspiel import KriegspielMove as KSMove
 from kriegspiel import MainAnnouncement as MA
+from kriegspiel import MaterialSideSummary
+from kriegspiel import PublicMaterialSummary
 from kriegspiel import QuestionAnnouncement as QA
 from kriegspiel import Wild16Game
+from kriegspiel.move import CapturedPieceAnnouncement as CPA
+from kriegspiel.move import KriegspielAnswer as KSAnswer
 from kriegspiel.rulesets import RULESET_BERKELEY
 from kriegspiel.rulesets import RULESET_BERKELEY_ANY
 from kriegspiel.snapshot import KriegspielGameSnapshot
 from kriegspiel.snapshot import ScoresheetSnapshot
 from kriegspiel.snapshot import move_stack_from_scoresheets
-from kriegspiel.move import KriegspielAnswer as KSAnswer
 
 
 def test_generic_game_defaults_to_berkeley_any():
@@ -105,8 +108,131 @@ def test_move_stack_from_scoresheets_handles_black_only_turns():
     assert move_stack_from_scoresheets(white_scoresheet, black_scoresheet) == ("e7e5",)
 
 
+@pytest.mark.parametrize(
+    "game",
+    [
+        pytest.param(BerkeleyGame(), id="berkeley-any"),
+        pytest.param(BerkeleyGame(any_rule=False), id="berkeley"),
+    ],
+)
+def test_public_material_summary_hides_pawn_capture_counts_for_berkeley_family(game):
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e2e4")))
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("d7d5")))
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e4d5")))
+
+    assert game.public_material_summary == PublicMaterialSummary(
+        white=MaterialSideSummary(pieces_remaining=16, pawns_captured=None),
+        black=MaterialSideSummary(pieces_remaining=15, pawns_captured=None),
+    )
+
+
+@pytest.mark.parametrize(
+    ("game", "expected_answer"),
+    [
+        pytest.param(
+            CincinnatiGame(),
+            KSAnswer(
+                MA.CAPTURE_DONE,
+                capture_at_square=chess.D5,
+                captured_piece_announcement=CPA.PAWN,
+                next_turn_has_pawn_capture=False,
+            ),
+            id="cincinnati",
+        ),
+        pytest.param(
+            Wild16Game(),
+            KSAnswer(
+                MA.CAPTURE_DONE,
+                capture_at_square=chess.D5,
+                captured_piece_announcement=CPA.PAWN,
+                next_turn_pawn_tries=0,
+            ),
+            id="wild16",
+        ),
+    ],
+)
+def test_public_material_summary_counts_public_pawn_captures_for_typed_rulesets(game, expected_answer):
+    assert game.public_material_summary == PublicMaterialSummary(
+        white=MaterialSideSummary(pieces_remaining=16, pawns_captured=0),
+        black=MaterialSideSummary(pieces_remaining=16, pawns_captured=0),
+    )
+
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e2e4")))
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("d7d5")))
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e4d5"))) == expected_answer
+    assert game.public_material_summary == PublicMaterialSummary(
+        white=MaterialSideSummary(pieces_remaining=16, pawns_captured=0),
+        black=MaterialSideSummary(pieces_remaining=15, pawns_captured=1),
+    )
+
+
+@pytest.mark.parametrize(
+    ("game", "expected_answer"),
+    [
+        pytest.param(
+            CincinnatiGame(),
+            KSAnswer(
+                MA.CAPTURE_DONE,
+                capture_at_square=chess.A5,
+                captured_piece_announcement=CPA.PIECE,
+                next_turn_has_pawn_capture=False,
+            ),
+            id="cincinnati",
+        ),
+        pytest.param(
+            Wild16Game(),
+            KSAnswer(
+                MA.CAPTURE_DONE,
+                capture_at_square=chess.A5,
+                captured_piece_announcement=CPA.PIECE,
+                next_turn_pawn_tries=0,
+            ),
+            id="wild16",
+        ),
+    ],
+)
+def test_public_material_summary_keeps_non_pawn_captures_out_of_pawn_count(game, expected_answer):
+    game._board.clear()
+    game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.A1, chess.Piece(chess.ROOK, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.A5, chess.Piece(chess.KNIGHT, chess.BLACK))
+    game._generate_possible_to_ask_list()
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move(chess.A1, chess.A5))) == expected_answer
+    assert game.public_material_summary == PublicMaterialSummary(
+        white=MaterialSideSummary(pieces_remaining=16, pawns_captured=0),
+        black=MaterialSideSummary(pieces_remaining=15, pawns_captured=0),
+    )
+
+
+def test_public_material_summary_does_not_treat_silent_promotion_as_a_pawn_capture():
+    game = Wild16Game()
+    game._board.clear()
+    game._board.set_piece_at(chess.F3, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.C1, chess.Piece(chess.BISHOP, chess.WHITE))
+    game._board.set_piece_at(chess.D2, chess.Piece(chess.PAWN, chess.BLACK))
+    game._board.turn = chess.BLACK
+    game._generate_possible_to_ask_list()
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move(chess.D2, chess.C1, promotion=chess.QUEEN))) == KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.C1,
+        captured_piece_announcement=CPA.PIECE,
+        next_turn_pawn_tries=0,
+    )
+    assert game.public_material_summary == PublicMaterialSummary(
+        white=MaterialSideSummary(pieces_remaining=15, pawns_captured=0),
+        black=MaterialSideSummary(pieces_remaining=16, pawns_captured=0),
+    )
+
+
 def test_package_root_exports_variant_entrypoints():
     assert KriegspielGame.__name__ == "KriegspielGame"
     assert BerkeleyGame.__name__ == "BerkeleyGame"
     assert CincinnatiGame.__name__ == "CincinnatiGame"
     assert Wild16Game.__name__ == "Wild16Game"
+    assert MaterialSideSummary.__name__ == "MaterialSideSummary"
+    assert PublicMaterialSummary.__name__ == "PublicMaterialSummary"


### PR DESCRIPTION
## What changed

- Added `PublicMaterialSummary` and `MaterialSideSummary` public dataclasses.
- Added `KriegspielGame.public_material_summary`, derived from completed public capture answers.
- Kept Berkeley/Berkeley+Any limited to remaining-piece counts, while Cincinnati and Wild 16 also expose pawn-capture counts from typed capture announcements.
- Bumped `kriegspiel` to `1.4.4` and documented the release note.

## Why

The UI currently estimates remaining material from rendered referee-log text. Material status belongs in the engine, where the ruleset policy already knows whether pawn-vs-piece capture information is public.

## Validation plan

- Run the full `ks-game` test suite with coverage on `rpis02-cf` against this branch.
- Use this package revision in backend/frontend follow-up PRs after the engine PR is merged.

## Deployment notes

- Publish `kriegspiel` `1.4.4` to PyPI after merge/tag so downstream services can consume the new public API.
