### PR TITLE
[codex] Fix README PyPI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # kriegspiel
 
-[![PyPI version](https://badge.fury.io/py/kriegspiel.svg)](https://pypi.org/project/kriegspiel/)
+[![PyPI version](https://img.shields.io/pypi/v/kriegspiel.svg?label=PyPI)](https://pypi.org/project/kriegspiel/)
 
 Python game engine for hidden-information Kriegspiel referee rules.
+
+You can try the rules in a live game at [kriegspiel.org](https://kriegspiel.org/).
 
 Current scope:
 - Berkeley Kriegspiel
@@ -68,4 +70,5 @@ print(wild16.current_turn_pawn_tries)
 ## Links
 
 - PyPI: [kriegspiel](https://pypi.org/project/kriegspiel/)
+- Live site: [kriegspiel.org](https://kriegspiel.org/)
 - Issues: [github.com/Kriegspiel/ks-game/issues](https://github.com/Kriegspiel/ks-game/issues)


### PR DESCRIPTION
## Summary

- Switch the README PyPI badge from Badge Fury to Shields' PyPI version endpoint.
- Add a short live-site note so readers know they can try Kriegspiel at `kriegspiel.org`.
- Add the live site to the README links section.

## Why

The Badge Fury badge was showing the stale `1.2.3` release even though PyPI currently reports `1.4.4`. The Shields endpoint reads the PyPI package version correctly.

## Validation

- Checked PyPI JSON for `kriegspiel` -> `1.4.4`.
- Checked the new Shields badge URL with `curl` -> contains `1.4.4`.
- Docs-only change; no package tests or version bump needed.
