### PR TITLE
Implement RAND ruleset engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Current scope:
 - Berkeley Kriegspiel
 - Berkeley + Any
 - Cincinnati
+- RAND
 - Wild 16
 
 The package models the referee, not a UI. You interact with it by asking questions as `KriegspielMove` objects and reading `KriegspielAnswer` results.
@@ -46,13 +47,16 @@ loaded = KriegspielGame.load_game("game.json")
 still use `BerkeleyGame` explicitly as a compatibility wrapper, or pick a ruleset
 with `ruleset=...`.
 
-Cincinnati and Wild 16 also have their own convenience entrypoints:
+Cincinnati, RAND, and Wild 16 also have their own convenience entrypoints:
 
 ```python
-from kriegspiel import CincinnatiGame, Wild16Game
+from kriegspiel import CincinnatiGame, RandGame, Wild16Game
 
 cincinnati = CincinnatiGame()
 print(cincinnati.current_turn_has_pawn_capture)
+
+rand = RandGame()
+print(rand.current_turn_pawn_try_squares)
 
 wild16 = Wild16Game()
 print(wild16.current_turn_pawn_tries)
@@ -63,6 +67,7 @@ print(wild16.current_turn_pawn_tries)
 - `KriegspielGame`: the neutral public entrypoint for the shared hidden-board engine
 - `BerkeleyGame`: backward-compatible Berkeley-named wrapper over `KriegspielGame`
 - `CincinnatiGame`: Cincinnati convenience entrypoint with public `NONSENSE` and binary pawn-capture announcements
+- `RandGame`: RAND convenience entrypoint with public rebuffs, pawn-try source-square announcements, typed captures, and promotion notices
 - `Wild16Game`: Wild 16 convenience entrypoint over the shared hidden-board engine
 - `KriegspielMove`: a player question, either a normal move or `ASK_ANY`
 - `KriegspielAnswer`: the referee response, including move outcome, captures, special announcements, and variant-specific public metadata

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## Kriegspiel v. 1.5.0
+
+- **RAND Support**: added first-class `rand` ruleset handling plus a dedicated `kriegspiel.rand.RandGame` convenience entrypoint.
+- **RAND Announcements**: added public rebuffs, typed pawn-vs-piece capture announcements, promotion notices, RAND pawn-try source-square announcements, and the RAND ladder stalemate rule.
+- **Serialization**: schema `7` now preserves RAND promotion and pawn-try-square metadata while still reading schemas `3`, `4`, `5`, and `6`.
+- **Testing**: added focused RAND engine, serialization, and rules-comparison coverage for pawn tries, en passant, promotion, public rebuffs, and stalemate.
+
 ## Kriegspiel v. 1.4.4
 
 - **Public Material Summary**: added an engine-owned material summary derived from completed public capture announcements, with ruleset-specific pawn-capture counts for Cincinnati and Wild 16.

--- a/kriegspiel/__init__.py
+++ b/kriegspiel/__init__.py
@@ -4,7 +4,7 @@ __author__ = "Alexander Filatov"
 
 __email__ = "alexander@kriegspiel.org"
 
-__version__ = "1.4.4"
+__version__ = "1.5.0"
 
 from kriegspiel.berkeley import BerkeleyGame
 from kriegspiel.cincinnati import CincinnatiGame
@@ -15,6 +15,7 @@ from kriegspiel.move import KriegspielMove
 from kriegspiel.move import MainAnnouncement
 from kriegspiel.move import QuestionAnnouncement
 from kriegspiel.move import SpecialCaseAnnouncement
+from kriegspiel.rand import RandGame
 from kriegspiel.snapshot import BerkeleyGameSnapshot
 from kriegspiel.snapshot import KriegspielGameSnapshot
 from kriegspiel.snapshot import MaterialSideSummary
@@ -35,6 +36,7 @@ __all__ = [
     "MaterialSideSummary",
     "PublicMaterialSummary",
     "QuestionAnnouncement",
+    "RandGame",
     "ScoresheetSnapshot",
     "SpecialCaseAnnouncement",
     "Wild16Game",

--- a/kriegspiel/game.py
+++ b/kriegspiel/game.py
@@ -27,9 +27,10 @@ class KriegspielGame(object):
     Shared hidden-board Kriegspiel referee engine.
 
     Ruleset-specific behavior such as Berkeley `ASK_ANY`, Cincinnati binary
-    pawn-capture announcements, or Wild 16 pawn-try counts is delegated to a
-    policy layer. Variant-named wrappers like `BerkeleyGame`, `CincinnatiGame`,
-    and `Wild16Game` build on this class.
+    pawn-capture announcements, RAND pawn-try source squares, or Wild 16
+    pawn-try counts is delegated to a policy layer. Variant-named wrappers like
+    `BerkeleyGame`, `CincinnatiGame`, `RandGame`, and `Wild16Game` build on this
+    class.
 
     Communication with this class must be in the form of questions —
     KriegspielMove(s) with QuestionAnnouncement(s).
@@ -46,7 +47,8 @@ class KriegspielGame(object):
             any_rule: Legacy compatibility flag for Berkeley+Any. When omitted,
                      Berkeley+Any remains the default.
             ruleset: Explicit ruleset identifier. Supported values are
-                     `berkeley`, `berkeley_any`, `cincinnati`, and `wild16`.
+                     `berkeley`, `berkeley_any`, `cincinnati`, `rand`, and
+                     `wild16`.
         """
         super().__init__()
         self._ruleset = resolve_ruleset_policy(ruleset=ruleset, any_rule=any_rule)
@@ -112,15 +114,22 @@ class KriegspielGame(object):
             if self._is_legal_move(move.chess_move):
                 # Move is legal in normal chess
                 # Perform normal move
-                captured_square, captured_piece_announcement = self._make_move(move.chess_move)
+                captured_square, captured_piece_announcement, promotion_announced = self._make_move(
+                    move.chess_move
+                )
                 special_case = self._check_special_cases()
                 next_turn_pawn_tries = self._ruleset.next_turn_pawn_tries(self)
                 next_turn_has_pawn_capture = self._ruleset.next_turn_has_pawn_capture(self)
+                next_turn_pawn_try_squares = self._ruleset.next_turn_pawn_try_squares(self)
                 answer_kwargs = {"special_announcement": special_case}
+                if promotion_announced:
+                    answer_kwargs["promotion_announced"] = True
                 if next_turn_pawn_tries is not None:
                     answer_kwargs["next_turn_pawn_tries"] = next_turn_pawn_tries
                 if next_turn_has_pawn_capture is not None:
                     answer_kwargs["next_turn_has_pawn_capture"] = next_turn_has_pawn_capture
+                if next_turn_pawn_try_squares is not None:
+                    answer_kwargs["next_turn_pawn_try_squares"] = next_turn_pawn_try_squares
                 if captured_square is not None:
                     # If it was capture
                     answer_kwargs["capture_at_square"] = captured_square
@@ -248,6 +257,12 @@ class KriegspielGame(object):
         if self.is_game_over():
             self._game_over = True
             if self._board.is_stalemate():
+                if self._ruleset.stalemate_loses:
+                    return (
+                        SCA.STALEMATE_BLACK_WINS
+                        if self._board.turn == chess.WHITE
+                        else SCA.STALEMATE_WHITE_WINS
+                    )
                 return SCA.DRAW_STALEMATE
             if self._board.is_insufficient_material():
                 return SCA.DRAW_INSUFFICIENT
@@ -307,12 +322,13 @@ class KriegspielGame(object):
         self._must_use_pawns = False
         captured_square = None
         captured_piece_announcement = None
+        promotion_announced = bool(move.promotion and self._ruleset.announce_promotion)
         if self._board.is_capture(move):
             captured_square = self._get_captured_square(move)
             captured_piece = self._get_captured_piece(move)
             captured_piece_announcement = self._ruleset.captured_piece_announcement_for(captured_piece)
         self._board.push(move)
-        return captured_square, captured_piece_announcement
+        return captured_square, captured_piece_announcement, promotion_announced
 
     def _legal_pawn_capture_moves(self):
         """Return legal pawn captures for the active player in the true position."""
@@ -322,6 +338,10 @@ class KriegspielGame(object):
             for move in self._board.legal_moves
             if move.from_square in pawn_squares and self._board.is_capture(move)
         ]
+
+    def _legal_pawn_capture_source_squares(self):
+        """Return distinct source squares of legal pawn captures for the active player."""
+        return tuple(sorted({move.from_square for move in self._legal_pawn_capture_moves()}))
 
     def _count_legal_pawn_captures(self):
         """Count distinct legal pawn-capture attempts in the true position."""
@@ -437,9 +457,8 @@ class KriegspielGame(object):
         # which contains info about previous moves.
         possibilities = {KSMove(QA.COMMON, chess_move) for chess_move in players_board.legal_moves}
         self._ruleset.add_special_questions(possibilities)
-        # Second add possible pawn captures
-        if self._ruleset.include_pawn_capture_attempts(self):
-            possibilities.update(self._generate_possible_pawn_captures())
+        # Second add ruleset-approved hidden pawn-capture tries.
+        possibilities.update(self._ruleset.pawn_capture_attempts_for_prompt(self))
         self._set_possible_to_ask(possibilities)
 
     @property
@@ -495,6 +514,16 @@ class KriegspielGame(object):
         """
         return self._ruleset.next_turn_has_pawn_capture(self)
 
+    @property
+    def current_turn_pawn_try_squares(self):
+        """
+        Get RAND-style pawn-capture source squares for the player to move.
+
+        Returns:
+            tuple[int] or None: Source squares when the active ruleset announces them.
+        """
+        return self._ruleset.next_turn_pawn_try_squares(self)
+
     @staticmethod
     def _capture_counts_from_completed_moves(moves_own):
         captures = 0
@@ -513,11 +542,11 @@ class KriegspielGame(object):
         """
         Return material information that is public under the active ruleset.
 
-        Total captures are public in all supported rulesets. Cincinnati and
-        Wild 16 additionally announce whether the captured man was a pawn, so
-        pawn-capture counts are exposed there. The summary is derived from
-        completed capture answers instead of true-board pawn counts, because
-        promotion is intentionally silent in those rulesets.
+        Total captures are public in all supported rulesets. Cincinnati, RAND,
+        and Wild 16 additionally announce whether the captured man was a pawn,
+        so pawn-capture counts are exposed there. The summary is derived from
+        completed capture answers instead of true-board pawn counts so promotion
+        remains tied to what the referee publicly announced.
         """
         white_captures, white_pawn_captures = self._capture_counts_from_completed_moves(
             self._whites_scoresheet.moves_own

--- a/kriegspiel/move.py
+++ b/kriegspiel/move.py
@@ -203,8 +203,8 @@ MOVE_DONE = [MainAnnouncement.REGULAR_MOVE, MainAnnouncement.CAPTURE_DONE]
 class SpecialCaseAnnouncement(enum.Enum):
     """
     If the move set the game in one of the special conditions,
-    then Special Case Announcement is used. There are five of them
-    for game end cases — as DRAW or CHECKMATE. Also, six of then for
+    then Special Case Announcement is used. There are seven of them
+    for game end cases — as DRAW, CHECKMATE, or RAND stalemate. Also, six of them for
     CHECK case. And one of them is technical — NONE.
     """
 
@@ -216,6 +216,8 @@ class SpecialCaseAnnouncement(enum.Enum):
 
     CHECKMATE_WHITE_WINS = 4
     CHECKMATE_BLACK_WINS = 5
+    STALEMATE_WHITE_WINS = 12
+    STALEMATE_BLACK_WINS = 13
 
     CHECK_RANK = 6
     CHECK_FILE = 7
@@ -266,6 +268,8 @@ class KriegspielAnswer(object):
                 captured_piece_announcement (CapturedPieceAnnouncement): Optional public
                                     capture detail for variants that distinguish pawn
                                     captures from other piece captures.
+                promotion_announced (bool): Optional RAND-style public statement that
+                                    a pawn promoted, without exposing piece type or square.
                 special_announcement: Optional special game state from SpecialCaseAnnouncement
                                     enum. Can be a single value or tuple for double check.
                                     For CHECK_DOUBLE, provide (CHECK_DOUBLE, [check1, check2]).
@@ -273,6 +277,8 @@ class KriegspielAnswer(object):
                                     captures available for the next player to move.
                 next_turn_has_pawn_capture (bool): Optional Cincinnati-style binary
                                     pawn-capture announcement for the next player to move.
+                next_turn_pawn_try_squares (tuple[int]): Optional RAND-style source
+                                    squares of pawns that have legal capture tries.
         
         Raises:
             TypeError: If main_announcement is not a MainAnnouncement enum value,
@@ -295,6 +301,8 @@ class KriegspielAnswer(object):
         self._check_2 = None
         self._next_turn_pawn_tries = None
         self._next_turn_has_pawn_capture = None
+        self._next_turn_pawn_try_squares = None
+        self._promotion_announced = False
 
         if main_announcement == MainAnnouncement.CAPTURE_DONE:
             # Validation, that when capture is done, then valid square should
@@ -354,8 +362,36 @@ class KriegspielAnswer(object):
                 raise TypeError("next_turn_has_pawn_capture must be a boolean")
             self._next_turn_has_pawn_capture = next_turn_has_pawn_capture
 
-        if self._next_turn_pawn_tries is not None and self._next_turn_has_pawn_capture is not None:
-            raise ValueError("Use either next_turn_pawn_tries or next_turn_has_pawn_capture, not both")
+        if "next_turn_pawn_try_squares" in kwargs:
+            try:
+                pawn_try_squares = tuple(kwargs["next_turn_pawn_try_squares"])
+            except TypeError as exc:
+                raise TypeError("next_turn_pawn_try_squares must be an iterable of square integers") from exc
+            if not all(isinstance(square, int) for square in pawn_try_squares):
+                raise TypeError("next_turn_pawn_try_squares must contain only integers")
+            invalid_squares = [square for square in pawn_try_squares if not (0 <= square <= 63)]
+            if invalid_squares:
+                raise ValueError(f"Invalid pawn try square: {invalid_squares[0]}. Must be 0-63.")
+            self._next_turn_pawn_try_squares = tuple(sorted(set(pawn_try_squares)))
+
+        if "promotion_announced" in kwargs:
+            promotion_announced = kwargs["promotion_announced"]
+            if not isinstance(promotion_announced, bool):
+                raise TypeError("promotion_announced must be a boolean")
+            self._promotion_announced = promotion_announced
+
+        pawn_capture_metadata_count = sum(
+            value is not None
+            for value in (
+                self._next_turn_pawn_tries,
+                self._next_turn_has_pawn_capture,
+                self._next_turn_pawn_try_squares,
+            )
+        )
+        if pawn_capture_metadata_count > 1:
+            raise ValueError(
+                "Use only one next-turn pawn-capture announcement field"
+            )
 
         if self._main_announcement in MOVE_DONE:
             self._move_done = True
@@ -434,6 +470,26 @@ class KriegspielAnswer(object):
         return self._next_turn_has_pawn_capture
 
     @property
+    def next_turn_pawn_try_squares(self):
+        """
+        Get the next player's RAND-style pawn-capture source squares.
+
+        Returns:
+            tuple[int] or None: Source squares of pawns with legal capture tries.
+        """
+        return self._next_turn_pawn_try_squares
+
+    @property
+    def promotion_announced(self):
+        """
+        Get whether the answer publicly announces that a pawn promoted.
+
+        Returns:
+            bool: True when the ruleset announces the fact of promotion.
+        """
+        return self._promotion_announced
+
+    @property
     def check_1(self):
         """
         Get the first check type in a double check situation.
@@ -475,6 +531,11 @@ class KriegspielAnswer(object):
         ]
         if self._next_turn_has_pawn_capture is not None:
             main_data.append(f"next_turn_has_pawn_capture={self._next_turn_has_pawn_capture}")
+        if self._next_turn_pawn_try_squares is not None:
+            square_names = tuple(chess.SQUARE_NAMES[square] for square in self._next_turn_pawn_try_squares)
+            main_data.append(f"next_turn_pawn_try_squares={square_names}")
+        if self._promotion_announced:
+            main_data.append("promotion_announced=True")
 
         if self._check_1 is not None or self._check_2 is not None:
             extra_data = f"check_1={self._check_1}, check_2={self._check_2}"
@@ -490,6 +551,8 @@ class KriegspielAnswer(object):
             self._special_announcement,
             self._next_turn_pawn_tries,
             self._next_turn_has_pawn_capture,
+            self._next_turn_pawn_try_squares,
+            self._promotion_announced,
             self._check_1,
             self._check_2,
         )
@@ -502,6 +565,8 @@ class KriegspielAnswer(object):
             self._special_announcement.value,
             self._next_turn_pawn_tries if self._next_turn_pawn_tries is not None else -1,
             -1 if self._next_turn_has_pawn_capture is None else int(self._next_turn_has_pawn_capture),
+            self._next_turn_pawn_try_squares or (),
+            int(self._promotion_announced),
             self._check_1.value if self._check_1 is not None else -1,
             self._check_2.value if self._check_2 is not None else -1,
         )
@@ -519,7 +584,7 @@ class KriegspielAnswer(object):
         """
         Check equality with another KriegspielAnswer.
         
-        Two answers are equal if their string representations match.
+        Two answers are equal if their structured referee payloads match.
         
         Args:
             other: Object to compare with.

--- a/kriegspiel/rand.py
+++ b/kriegspiel/rand.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+"""Convenience entrypoint for the RAND Kriegspiel ruleset."""
+
+from __future__ import annotations
+
+from kriegspiel.game import KriegspielGame
+from kriegspiel.move import KriegspielScoresheet as KSSS
+from kriegspiel.rulesets import RULESET_RAND
+from kriegspiel.serialization import load_game_from_json
+
+
+class RandGame(KriegspielGame):
+    """RAND convenience wrapper over the shared hidden-board engine."""
+
+    def __init__(self):
+        super().__init__(ruleset=RULESET_RAND)
+
+    @classmethod
+    def _from_kriegspiel_game(cls, game):
+        """Rebuild a RandGame wrapper from a validated shared-engine instance."""
+        if not isinstance(game, KriegspielGame):
+            raise TypeError("game must be a KriegspielGame")
+        if game.ruleset_id != RULESET_RAND:
+            raise ValueError("game must use the rand ruleset")
+
+        instance = cls()
+        instance._board = game._board.copy(stack=True)
+        instance._must_use_pawns = game._must_use_pawns
+        instance._game_over = game._game_over
+        instance._possible_to_ask = list(game.possible_to_ask)
+        instance._possible_to_ask_set = set(game.possible_to_ask)
+        instance._whites_scoresheet = KSSS.from_snapshot(game._whites_scoresheet.snapshot())
+        instance._blacks_scoresheet = KSSS.from_snapshot(game._blacks_scoresheet.snapshot())
+        return instance
+
+    @classmethod
+    def from_snapshot(cls, snapshot):
+        """Build a RandGame from a validated snapshot."""
+        return cls._from_kriegspiel_game(KriegspielGame.from_snapshot(snapshot))
+
+    @classmethod
+    def load_game(cls, filename):
+        """Load a RAND game from disk."""
+        return cls._from_kriegspiel_game(load_game_from_json(filename))

--- a/kriegspiel/rulesets.py
+++ b/kriegspiel/rulesets.py
@@ -16,6 +16,7 @@ from kriegspiel.move import QuestionAnnouncement as QA
 RULESET_BERKELEY = "berkeley"
 RULESET_BERKELEY_ANY = "berkeley_any"
 RULESET_CINCINNATI = "cincinnati"
+RULESET_RAND = "rand"
 RULESET_WILD16 = "wild16"
 
 
@@ -35,20 +36,31 @@ class BerkeleyRulesetPolicy:
     discard_illegal_attempts: bool
     public_illegal_attempts: bool
     typed_capture_announcements: bool
+    announce_promotion: bool
     announce_next_turn_pawn_tries: bool
     announce_next_turn_has_pawn_capture: bool
+    announce_next_turn_pawn_try_squares: bool
+    stalemate_loses: bool
 
     def add_special_questions(self, possibilities: set[KSMove]) -> None:
         if self.allow_ask_any:
             possibilities.add(KSMove(QA.ASK_ANY))
 
-    def include_pawn_capture_attempts(self, game) -> bool:
-        """Return whether hidden pawn-capture tries belong in this prompt."""
+    def pawn_capture_attempts_for_prompt(self, game) -> set[KSMove]:
+        """Return hidden pawn-capture tries that belong in this prompt."""
+        pawn_captures = set(game._generate_possible_pawn_captures())
         if self.announce_next_turn_has_pawn_capture:
-            return game._has_any_pawn_captures()
+            return pawn_captures if game._has_any_pawn_captures() else set()
         if self.announce_next_turn_pawn_tries:
-            return game._count_legal_pawn_captures() > 0
-        return True
+            return pawn_captures if game._count_legal_pawn_captures() > 0 else set()
+        if self.announce_next_turn_pawn_try_squares:
+            legal_sources = set(game._legal_pawn_capture_source_squares())
+            return {
+                move
+                for move in pawn_captures
+                if move.chess_move is not None and move.chess_move.from_square in legal_sources
+            }
+        return pawn_captures
 
     def classify_impossible_common_attempt(self) -> MA:
         return self.invalid_common_attempt_result
@@ -104,6 +116,11 @@ class BerkeleyRulesetPolicy:
             return None
         return game._has_any_pawn_captures()
 
+    def next_turn_pawn_try_squares(self, game) -> tuple[int, ...] | None:
+        if not self.announce_next_turn_pawn_try_squares or game.game_over:
+            return None
+        return game._legal_pawn_capture_source_squares()
+
 
 def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None = None) -> BerkeleyRulesetPolicy:
     """Resolve legacy `any_rule` calls into an explicit ruleset policy."""
@@ -125,8 +142,11 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             discard_illegal_attempts=True,
             public_illegal_attempts=True,
             typed_capture_announcements=False,
+            announce_promotion=False,
             announce_next_turn_pawn_tries=False,
             announce_next_turn_has_pawn_capture=False,
+            announce_next_turn_pawn_try_squares=False,
+            stalemate_loses=False,
         )
     if ruleset == RULESET_BERKELEY:
         return BerkeleyRulesetPolicy(
@@ -136,8 +156,11 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             discard_illegal_attempts=True,
             public_illegal_attempts=True,
             typed_capture_announcements=False,
+            announce_promotion=False,
             announce_next_turn_pawn_tries=False,
             announce_next_turn_has_pawn_capture=False,
+            announce_next_turn_pawn_try_squares=False,
+            stalemate_loses=False,
         )
     if ruleset == RULESET_CINCINNATI:
         return BerkeleyRulesetPolicy(
@@ -147,8 +170,25 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             discard_illegal_attempts=True,
             public_illegal_attempts=True,
             typed_capture_announcements=True,
+            announce_promotion=False,
             announce_next_turn_pawn_tries=False,
             announce_next_turn_has_pawn_capture=True,
+            announce_next_turn_pawn_try_squares=False,
+            stalemate_loses=False,
+        )
+    if ruleset == RULESET_RAND:
+        return BerkeleyRulesetPolicy(
+            identifier=ruleset,
+            allow_ask_any=False,
+            invalid_common_attempt_result=MA.NONSENSE,
+            discard_illegal_attempts=True,
+            public_illegal_attempts=True,
+            typed_capture_announcements=True,
+            announce_promotion=True,
+            announce_next_turn_pawn_tries=False,
+            announce_next_turn_has_pawn_capture=False,
+            announce_next_turn_pawn_try_squares=True,
+            stalemate_loses=True,
         )
     if ruleset == RULESET_WILD16:
         return BerkeleyRulesetPolicy(
@@ -158,7 +198,10 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             discard_illegal_attempts=True,
             public_illegal_attempts=False,
             typed_capture_announcements=True,
+            announce_promotion=False,
             announce_next_turn_pawn_tries=True,
             announce_next_turn_has_pawn_capture=False,
+            announce_next_turn_pawn_try_squares=False,
+            stalemate_loses=False,
         )
     raise ValueError(f"Unsupported ruleset: {ruleset!r}")

--- a/kriegspiel/serialization.py
+++ b/kriegspiel/serialization.py
@@ -8,8 +8,8 @@ Kriegspiel game components using JSON format with custom encoders/decoders.
 
 JSON Schema Structure:
 {
-  "schema_version": 6,
-  "library_version": "1.4.0",
+  "schema_version": 7,
+  "library_version": "1.5.0",
   "game_type": "BerkeleyGame",
   "game_state": {
     "ruleset_id": "berkeley_any",
@@ -46,9 +46,11 @@ moves_own/moves_opponent: [
         "main_announcement": "REGULAR_MOVE" | "CAPTURE_DONE" | ...,
         "capture_at_square": int | null,
         "captured_piece_announcement": "PAWN" | "PIECE" | null,
+        "promotion_announced": bool | null,
         "special_announcement": "NONE" | "CHECK_RANK" | ...,
         "next_turn_pawn_tries": int | null,
         "next_turn_has_pawn_capture": bool | null,
+        "next_turn_pawn_try_squares": [int] | null,
         "check_1": "CHECK_RANK" | null,  // For double check
         "check_2": "CHECK_FILE" | null   // For double check
       }
@@ -77,7 +79,8 @@ from kriegspiel import __version__
 LEGACY_SERIALIZATION_SCHEMA_VERSION = 3
 INTERMEDIATE_SERIALIZATION_SCHEMA_VERSION = 4
 PREVIOUS_SERIALIZATION_SCHEMA_VERSION = 5
-SERIALIZATION_SCHEMA_VERSION = 6
+CINCINNATI_SERIALIZATION_SCHEMA_VERSION = 6
+SERIALIZATION_SCHEMA_VERSION = 7
 
 
 class SerializationError(Exception):
@@ -222,8 +225,12 @@ def serialize_kriegspiel_answer(answer: KriegspielAnswer) -> Dict[str, Any]:
         "check_1": serialize_enum(answer.check_1) if answer.check_1 is not None else None,
         "check_2": serialize_enum(answer.check_2) if answer.check_2 is not None else None
     }
+    if answer.promotion_announced:
+        result["promotion_announced"] = True
     if answer.next_turn_has_pawn_capture is not None:
         result["next_turn_has_pawn_capture"] = answer.next_turn_has_pawn_capture
+    if answer.next_turn_pawn_try_squares is not None:
+        result["next_turn_pawn_try_squares"] = list(answer.next_turn_pawn_try_squares)
     return result
 
 
@@ -245,6 +252,10 @@ def deserialize_kriegspiel_answer(data: Dict[str, Any]) -> KriegspielAnswer:
             kwargs["next_turn_pawn_tries"] = data["next_turn_pawn_tries"]
         if data.get("next_turn_has_pawn_capture") is not None:
             kwargs["next_turn_has_pawn_capture"] = data["next_turn_has_pawn_capture"]
+        if data.get("next_turn_pawn_try_squares") is not None:
+            kwargs["next_turn_pawn_try_squares"] = data["next_turn_pawn_try_squares"]
+        if data.get("promotion_announced") is not None:
+            kwargs["promotion_announced"] = data["promotion_announced"]
         
         special_announcement = deserialize_special_case_announcement(data["special_announcement"])
         
@@ -336,7 +347,7 @@ def serialize_berkeley_game(game) -> Dict[str, Any]:
 def deserialize_berkeley_game(data: Dict[str, Any]):
     """Deserialize dictionary to a shared KriegspielGame instance."""
     try:
-        # Check schema compatibility. Live data uses schema 3/4; new writes use schema 5.
+        # Check schema compatibility. Live data uses schema 3+; new writes use schema 7.
         schema_version = data.get("schema_version")
         if schema_version is None:
             raise UnsupportedVersionError("Missing schema_version")
@@ -344,6 +355,7 @@ def deserialize_berkeley_game(data: Dict[str, Any]):
             LEGACY_SERIALIZATION_SCHEMA_VERSION,
             INTERMEDIATE_SERIALIZATION_SCHEMA_VERSION,
             PREVIOUS_SERIALIZATION_SCHEMA_VERSION,
+            CINCINNATI_SERIALIZATION_SCHEMA_VERSION,
             SERIALIZATION_SCHEMA_VERSION,
         }:
             raise UnsupportedVersionError(f"Unsupported schema_version: {schema_version}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "kriegspiel"
 dynamic = ["version", "readme"]
-description = "Python hidden-information chess engine for Berkeley-family Kriegspiel variants"
+description = "Python hidden-information chess engine for Kriegspiel variants"
 requires-python = ">=3.9"
 license = "MIT"
 authors = [

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -16,6 +16,7 @@ from kriegspiel import MainAnnouncement as MA
 from kriegspiel import MaterialSideSummary
 from kriegspiel import PublicMaterialSummary
 from kriegspiel import QuestionAnnouncement as QA
+from kriegspiel import RandGame
 from kriegspiel import Wild16Game
 from kriegspiel.move import CapturedPieceAnnouncement as CPA
 from kriegspiel.move import KriegspielAnswer as KSAnswer
@@ -149,6 +150,16 @@ def test_public_material_summary_hides_pawn_capture_counts_for_berkeley_family(g
             ),
             id="wild16",
         ),
+        pytest.param(
+            RandGame(),
+            KSAnswer(
+                MA.CAPTURE_DONE,
+                capture_at_square=chess.D5,
+                captured_piece_announcement=CPA.PAWN,
+                next_turn_pawn_try_squares=tuple(),
+            ),
+            id="rand",
+        ),
     ],
 )
 def test_public_material_summary_counts_public_pawn_captures_for_typed_rulesets(game, expected_answer):
@@ -190,6 +201,16 @@ def test_public_material_summary_counts_public_pawn_captures_for_typed_rulesets(
             ),
             id="wild16",
         ),
+        pytest.param(
+            RandGame(),
+            KSAnswer(
+                MA.CAPTURE_DONE,
+                capture_at_square=chess.A5,
+                captured_piece_announcement=CPA.PIECE,
+                next_turn_pawn_try_squares=tuple(),
+            ),
+            id="rand",
+        ),
     ],
 )
 def test_public_material_summary_keeps_non_pawn_captures_out_of_pawn_count(game, expected_answer):
@@ -229,10 +250,34 @@ def test_public_material_summary_does_not_treat_silent_promotion_as_a_pawn_captu
     )
 
 
+def test_public_material_summary_handles_rand_announced_promotion_without_pawn_capture():
+    game = RandGame()
+    game._board.clear()
+    game._board.set_piece_at(chess.F3, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.C1, chess.Piece(chess.BISHOP, chess.WHITE))
+    game._board.set_piece_at(chess.D2, chess.Piece(chess.PAWN, chess.BLACK))
+    game._board.turn = chess.BLACK
+    game._generate_possible_to_ask_list()
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move(chess.D2, chess.C1, promotion=chess.QUEEN))) == KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.C1,
+        captured_piece_announcement=CPA.PIECE,
+        promotion_announced=True,
+        next_turn_pawn_try_squares=tuple(),
+    )
+    assert game.public_material_summary == PublicMaterialSummary(
+        white=MaterialSideSummary(pieces_remaining=15, pawns_captured=0),
+        black=MaterialSideSummary(pieces_remaining=16, pawns_captured=0),
+    )
+
+
 def test_package_root_exports_variant_entrypoints():
     assert KriegspielGame.__name__ == "KriegspielGame"
     assert BerkeleyGame.__name__ == "BerkeleyGame"
     assert CincinnatiGame.__name__ == "CincinnatiGame"
+    assert RandGame.__name__ == "RandGame"
     assert Wild16Game.__name__ == "Wild16Game"
     assert MaterialSideSummary.__name__ == "MaterialSideSummary"
     assert PublicMaterialSummary.__name__ == "PublicMaterialSummary"

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -252,12 +252,46 @@ def test_next_turn_has_pawn_capture_validation():
         KSAnswer(MA.REGULAR_MOVE, next_turn_has_pawn_capture="yes")
 
 
+def test_next_turn_pawn_try_squares_validation_and_normalization():
+    answer = KSAnswer(
+        MA.REGULAR_MOVE,
+        next_turn_pawn_try_squares=[chess.E4, chess.C2, chess.E4],
+    )
+
+    assert answer.next_turn_pawn_try_squares == (chess.C2, chess.E4)
+
+    with pytest.raises(TypeError, match="next_turn_pawn_try_squares must be an iterable"):
+        KSAnswer(MA.REGULAR_MOVE, next_turn_pawn_try_squares=chess.E4)
+
+    with pytest.raises(TypeError, match="next_turn_pawn_try_squares must contain only integers"):
+        KSAnswer(MA.REGULAR_MOVE, next_turn_pawn_try_squares=[chess.E4, "e5"])
+
+    with pytest.raises(ValueError, match="Invalid pawn try square: 64. Must be 0-63."):
+        KSAnswer(MA.REGULAR_MOVE, next_turn_pawn_try_squares=[64])
+
+
+def test_promotion_announced_validation():
+    answer = KSAnswer(MA.REGULAR_MOVE, promotion_announced=True)
+
+    assert answer.promotion_announced is True
+
+    with pytest.raises(TypeError, match="promotion_announced must be a boolean"):
+        KSAnswer(MA.REGULAR_MOVE, promotion_announced="yes")
+
+
 def test_next_turn_pawn_capture_metadata_is_mutually_exclusive():
-    with pytest.raises(ValueError, match="Use either next_turn_pawn_tries or next_turn_has_pawn_capture"):
+    with pytest.raises(ValueError, match="Use only one next-turn pawn-capture announcement field"):
         KSAnswer(
             MA.REGULAR_MOVE,
             next_turn_pawn_tries=1,
             next_turn_has_pawn_capture=True,
+        )
+
+    with pytest.raises(ValueError, match="Use only one next-turn pawn-capture announcement field"):
+        KSAnswer(
+            MA.REGULAR_MOVE,
+            next_turn_has_pawn_capture=False,
+            next_turn_pawn_try_squares=tuple(),
         )
 
 
@@ -400,6 +434,21 @@ def test_ksanswer_str_with_cincinnati_pawn_capture_payload():
         "<KriegspielAnswer: MainAnnouncement.REGULAR_MOVE, "
         "capture_at=None, captured_piece=None, special_case=SpecialCaseAnnouncement.NONE, "
         "next_turn_pawn_tries=None, next_turn_has_pawn_capture=True>"
+    )
+
+
+def test_ksanswer_str_with_rand_payload():
+    answer = KSAnswer(
+        MA.REGULAR_MOVE,
+        next_turn_pawn_try_squares=(chess.E4,),
+        promotion_announced=True,
+    )
+
+    assert str(answer) == (
+        "<KriegspielAnswer: MainAnnouncement.REGULAR_MOVE, "
+        "capture_at=None, captured_piece=None, special_case=SpecialCaseAnnouncement.NONE, "
+        "next_turn_pawn_tries=None, next_turn_pawn_try_squares=('e4',), "
+        "promotion_announced=True>"
     )
 
 

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -123,7 +123,7 @@ def test_rand_en_passant_uses_capturable_pawn_source_and_captured_pawn_square():
         MA.CAPTURE_DONE,
         capture_at_square=chess.D5,
         captured_piece_announcement=CPA.PAWN,
-        next_turn_pawn_try_squares=tuple(),
+        next_turn_pawn_try_squares=(chess.C7, chess.E7),
     )
 
 

--- a/tests/test_rand.py
+++ b/tests/test_rand.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+
+"""RAND-specific engine and convenience entrypoint tests."""
+
+import os
+import tempfile
+
+import pytest
+
+from kriegspiel.berkeley import BerkeleyGame, chess
+from kriegspiel.move import CapturedPieceAnnouncement as CPA
+from kriegspiel.move import KriegspielAnswer as KSAnswer
+from kriegspiel.move import KriegspielMove as KSMove
+from kriegspiel.move import MainAnnouncement as MA
+from kriegspiel.move import QuestionAnnouncement as QA
+from kriegspiel.move import SpecialCaseAnnouncement as SCA
+from kriegspiel.rand import RandGame
+from kriegspiel.rulesets import RULESET_RAND, resolve_ruleset_policy
+
+
+def _build_rand_pawn_try_game():
+    game = RandGame()
+    game._board.clear()
+    game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.C4, chess.Piece(chess.PAWN, chess.WHITE))
+    game._board.set_piece_at(chess.E4, chess.Piece(chess.PAWN, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.F5, chess.Piece(chess.ROOK, chess.BLACK))
+    game._generate_possible_to_ask_list()
+    return game
+
+
+def test_rand_game_uses_rand_ruleset():
+    game = RandGame()
+
+    assert game.ruleset_id == RULESET_RAND
+    assert game.any_rule is False
+    assert KSMove(QA.ASK_ANY) not in game.possible_to_ask
+    assert game.current_turn_pawn_try_squares == tuple()
+    assert game.current_turn_has_pawn_capture is None
+    assert game.current_turn_pawn_tries is None
+
+
+def test_rand_policy_uses_public_rebuffs_typed_captures_and_promotion_notices():
+    policy = resolve_ruleset_policy(ruleset=RULESET_RAND)
+
+    assert policy.classify_impossible_common_attempt() == MA.NONSENSE
+    assert policy.public_illegal_attempts is True
+    assert policy.discard_illegal_attempts is True
+    assert policy.typed_capture_announcements is True
+    assert policy.announce_promotion is True
+    assert policy.stalemate_loses is True
+
+
+def test_rand_announces_only_pawn_source_squares_with_legal_capture_tries():
+    game = _build_rand_pawn_try_game()
+    legal_try = KSMove(QA.COMMON, chess.Move(chess.E4, chess.F5))
+    unannounced_pawn_try = KSMove(QA.COMMON, chess.Move(chess.C4, chess.D5))
+
+    assert game.current_turn_pawn_try_squares == (chess.E4,)
+    assert legal_try in game.possible_to_ask
+    assert unannounced_pawn_try not in game.possible_to_ask
+    assert game.ask_for(unannounced_pawn_try) == KSAnswer(MA.NONSENSE)
+
+
+def test_rand_completed_move_announces_next_turn_pawn_try_squares():
+    game = RandGame()
+
+    game.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+    result = game.ask_for(KSMove(QA.COMMON, chess.Move(chess.D7, chess.D5)))
+
+    assert result == KSAnswer(MA.REGULAR_MOVE, next_turn_pawn_try_squares=(chess.E4,))
+    assert game.current_turn_pawn_try_squares == (chess.E4,)
+
+
+def test_rand_capture_announces_square_piece_kind_and_next_pawn_try_squares():
+    game = _build_rand_pawn_try_game()
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move(chess.E4, chess.F5))) == KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.F5,
+        captured_piece_announcement=CPA.PIECE,
+        next_turn_pawn_try_squares=tuple(),
+    )
+
+
+def test_rand_public_rebuffs_are_visible_to_opponent_and_repeated_try_is_nonsense():
+    game = RandGame()
+    game._board.clear()
+    game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.A1, chess.Piece(chess.ROOK, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.A3, chess.Piece(chess.KNIGHT, chess.BLACK))
+    game._generate_possible_to_ask_list()
+
+    first_try = KSMove(QA.COMMON, chess.Move(chess.A1, chess.A5))
+
+    assert game.ask_for(first_try) == KSAnswer(MA.ILLEGAL_MOVE)
+    assert game.ask_for(first_try) == KSAnswer(MA.NONSENSE)
+    assert len(game._whites_scoresheet.moves_own[0]) == 2
+    assert len(game._blacks_scoresheet.moves_opponent[0]) == 2
+    assert [answer.main_announcement for _question, answer in game._blacks_scoresheet.moves_opponent[0]] == [
+        MA.ILLEGAL_MOVE,
+        MA.NONSENSE,
+    ]
+
+
+def test_rand_ask_any_is_not_supported():
+    game = RandGame()
+
+    assert game.ask_for(KSMove(QA.ASK_ANY)) == KSAnswer(MA.IMPOSSIBLE_TO_ASK)
+
+
+def test_rand_en_passant_uses_capturable_pawn_source_and_captured_pawn_square():
+    game = RandGame()
+    game.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+    game.ask_for(KSMove(QA.COMMON, chess.Move(chess.H7, chess.H6)))
+    game.ask_for(KSMove(QA.COMMON, chess.Move(chess.E4, chess.E5)))
+    result = game.ask_for(KSMove(QA.COMMON, chess.Move(chess.D7, chess.D5)))
+
+    assert result.next_turn_pawn_try_squares == (chess.E5,)
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move(chess.E5, chess.D6))) == KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.D5,
+        captured_piece_announcement=CPA.PAWN,
+        next_turn_pawn_try_squares=tuple(),
+    )
+
+
+def test_rand_pawn_try_squares_only_include_captures_that_escape_check():
+    game = RandGame()
+    game._board.clear()
+    game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.C2, chess.Piece(chess.PAWN, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.D3, chess.Piece(chess.KNIGHT, chess.BLACK))
+    game._generate_possible_to_ask_list()
+
+    assert game._board.is_check()
+    assert game.current_turn_pawn_try_squares == (chess.C2,)
+    assert KSMove(QA.COMMON, chess.Move(chess.C2, chess.D3)) in game.possible_to_ask
+
+
+def test_rand_ignores_pawn_captures_that_do_not_escape_check():
+    game = RandGame()
+    game._board.clear()
+    game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.D2, chess.Piece(chess.PAWN, chess.WHITE))
+    game._board.set_piece_at(chess.A1, chess.Piece(chess.ROOK, chess.BLACK))
+    game._board.set_piece_at(chess.E3, chess.Piece(chess.BISHOP, chess.BLACK))
+    game._generate_possible_to_ask_list()
+
+    assert game._board.is_check()
+    assert game.current_turn_pawn_try_squares == tuple()
+    assert KSMove(QA.COMMON, chess.Move(chess.D2, chess.E3)) not in game.possible_to_ask
+
+
+def test_rand_announces_promotion_without_piece_type_or_square():
+    game = RandGame()
+    game._board.clear()
+    game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.H7, chess.Piece(chess.PAWN, chess.WHITE))
+    game._board.set_piece_at(chess.A4, chess.Piece(chess.KING, chess.BLACK))
+    game._generate_possible_to_ask_list()
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move(chess.H7, chess.H8, promotion=chess.QUEEN))) == KSAnswer(
+        MA.REGULAR_MOVE,
+        promotion_announced=True,
+        next_turn_pawn_try_squares=tuple(),
+    )
+
+
+def test_rand_announces_capture_and_promotion_together():
+    game = RandGame()
+    game._board.clear()
+    game._board.set_piece_at(chess.F3, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.D2, chess.Piece(chess.PAWN, chess.BLACK))
+    game._board.set_piece_at(chess.C1, chess.Piece(chess.BISHOP, chess.WHITE))
+    game._board.turn = chess.BLACK
+    game._generate_possible_to_ask_list()
+
+    assert game.current_turn_pawn_try_squares == (chess.D2,)
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move(chess.D2, chess.C1, promotion=chess.QUEEN))) == KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.C1,
+        captured_piece_announcement=CPA.PIECE,
+        promotion_announced=True,
+        next_turn_pawn_try_squares=tuple(),
+    )
+
+
+def test_rand_ladder_stalemate_is_loss_for_stalemated_side():
+    game = RandGame()
+    game._board.clear()
+    game._board.set_piece_at(chess.F7, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.G5, chess.Piece(chess.QUEEN, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._generate_possible_to_ask_list()
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move(chess.G5, chess.G6))) == KSAnswer(
+        MA.REGULAR_MOVE,
+        special_announcement=SCA.STALEMATE_WHITE_WINS,
+    )
+
+
+def test_rand_from_snapshot_returns_variant_instance():
+    game = RandGame()
+    game.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+
+    restored = RandGame.from_snapshot(game.snapshot())
+
+    assert isinstance(restored, RandGame)
+    assert restored.ruleset_id == RULESET_RAND
+    assert restored._board.fen() == game._board.fen()
+
+
+def test_rand_from_snapshot_rejects_other_ruleset():
+    game = BerkeleyGame(any_rule=False)
+
+    with pytest.raises(ValueError, match="rand ruleset"):
+        RandGame.from_snapshot(game.snapshot())
+
+
+def test_rand_private_helper_rejects_non_game():
+    with pytest.raises(TypeError, match="KriegspielGame"):
+        RandGame._from_kriegspiel_game("not-a-game")
+
+
+def test_rand_load_game_returns_variant_instance():
+    game = RandGame()
+    game.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as handle:
+        filename = handle.name
+
+    try:
+        game.save_game(filename)
+        restored = RandGame.load_game(filename)
+    finally:
+        os.unlink(filename)
+
+    assert isinstance(restored, RandGame)
+    assert restored.ruleset_id == RULESET_RAND
+    assert restored._board.fen() == game._board.fen()
+
+
+def test_rand_load_game_rejects_other_ruleset():
+    game = BerkeleyGame(any_rule=False)
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as handle:
+        filename = handle.name
+
+    try:
+        game.save_game(filename)
+        with pytest.raises(ValueError, match="rand ruleset"):
+            RandGame.load_game(filename)
+    finally:
+        os.unlink(filename)

--- a/tests/test_rules_comparison.py
+++ b/tests/test_rules_comparison.py
@@ -11,6 +11,7 @@ from kriegspiel.move import KriegspielAnswer as KSAnswer
 from kriegspiel.move import KriegspielMove as KSMove
 from kriegspiel.move import MainAnnouncement as MA
 from kriegspiel.move import QuestionAnnouncement as QA
+from kriegspiel.rand import RandGame
 from kriegspiel.wild16 import Wild16Game
 
 
@@ -58,15 +59,17 @@ def _promotion_capture_moves():
 
 
 @pytest.mark.rules
-def test_rules_comparison_position_announces_binary_vs_counted_pawn_captures():
+def test_rules_comparison_position_announces_ruleset_specific_pawn_capture_metadata():
     berkeley_any = _build_rules_comparison_game(BerkeleyGame())
     berkeley = _build_rules_comparison_game(BerkeleyGame(any_rule=False))
     cincinnati = _build_rules_comparison_game(CincinnatiGame())
+    rand = _build_rules_comparison_game(RandGame())
     wild16 = _build_rules_comparison_game(Wild16Game())
 
     assert KSMove(QA.ASK_ANY) in berkeley_any.possible_to_ask
     assert KSMove(QA.ASK_ANY) not in berkeley.possible_to_ask
     assert KSMove(QA.ASK_ANY) not in cincinnati.possible_to_ask
+    assert KSMove(QA.ASK_ANY) not in rand.possible_to_ask
     assert KSMove(QA.ASK_ANY) not in wild16.possible_to_ask
 
     assert berkeley_any.current_turn_has_pawn_capture is None
@@ -75,6 +78,9 @@ def test_rules_comparison_position_announces_binary_vs_counted_pawn_captures():
     assert berkeley.current_turn_pawn_tries is None
     assert cincinnati.current_turn_has_pawn_capture is True
     assert cincinnati.current_turn_pawn_tries is None
+    assert rand.current_turn_has_pawn_capture is None
+    assert rand.current_turn_pawn_tries is None
+    assert rand.current_turn_pawn_try_squares == (chess.E4,)
     assert wild16.current_turn_has_pawn_capture is None
     assert wild16.current_turn_pawn_tries == 2
 
@@ -86,6 +92,7 @@ def test_rules_comparison_position_announces_binary_vs_counted_pawn_captures():
         pytest.param(BerkeleyGame(), None, None, id="berkeley-any"),
         pytest.param(BerkeleyGame(any_rule=False), None, None, id="berkeley"),
         pytest.param(CincinnatiGame(), True, None, id="cincinnati"),
+        pytest.param(RandGame(), None, None, id="rand"),
         pytest.param(Wild16Game(), None, 1, id="wild16"),
     ],
 )
@@ -102,6 +109,8 @@ def test_rules_comparison_promotion_capture_counts_as_one_pawn_capture(
     assert game._has_any_pawn_captures() is True
     assert game.current_turn_has_pawn_capture is expected_has_pawn_capture
     assert game.current_turn_pawn_tries == expected_pawn_tries
+    if isinstance(game, RandGame):
+        assert game.current_turn_pawn_try_squares == (chess.D2,)
 
 
 @pytest.mark.rules
@@ -127,6 +136,16 @@ def test_rules_comparison_promotion_capture_counts_as_one_pawn_capture(
                 next_turn_has_pawn_capture=False,
             ),
             id="cincinnati",
+        ),
+        pytest.param(
+            RandGame(),
+            KSAnswer(
+                MA.CAPTURE_DONE,
+                capture_at_square=chess.A5,
+                captured_piece_announcement=CPA.PIECE,
+                next_turn_pawn_try_squares=tuple(),
+            ),
+            id="rand",
         ),
         pytest.param(
             Wild16Game(),
@@ -194,6 +213,16 @@ def test_rules_comparison_berkeley_family_can_try_pawn_captures_without_announce
                 next_turn_pawn_tries=0,
             ),
             id="wild16",
+        ),
+        pytest.param(
+            RandGame(),
+            KSAnswer(
+                MA.CAPTURE_DONE,
+                capture_at_square=chess.D5,
+                captured_piece_announcement=CPA.PIECE,
+                next_turn_pawn_try_squares=tuple(),
+            ),
+            id="rand",
         ),
     ],
 )

--- a/tests/test_rulesets.py
+++ b/tests/test_rulesets.py
@@ -12,6 +12,7 @@ from kriegspiel.move import QuestionAnnouncement as QA
 from kriegspiel.rulesets import RULESET_BERKELEY
 from kriegspiel.rulesets import RULESET_BERKELEY_ANY
 from kriegspiel.rulesets import RULESET_CINCINNATI
+from kriegspiel.rulesets import RULESET_RAND
 from kriegspiel.rulesets import RULESET_WILD16
 from kriegspiel.rulesets import resolve_ruleset_policy
 
@@ -20,6 +21,7 @@ def test_resolve_ruleset_policy_accepts_matching_any_rule_flags():
     assert resolve_ruleset_policy(ruleset=RULESET_BERKELEY_ANY, any_rule=True).identifier == RULESET_BERKELEY_ANY
     assert resolve_ruleset_policy(ruleset=RULESET_BERKELEY, any_rule=False).identifier == RULESET_BERKELEY
     assert resolve_ruleset_policy(ruleset=RULESET_CINCINNATI, any_rule=False).identifier == RULESET_CINCINNATI
+    assert resolve_ruleset_policy(ruleset=RULESET_RAND, any_rule=False).identifier == RULESET_RAND
 
 
 def test_ruleset_policy_controls_opponent_visibility():
@@ -46,4 +48,20 @@ def test_ruleset_policy_announces_binary_pawn_capture_for_cincinnati():
     fake_game = type("FakeGame", (), {"game_over": False, "_has_any_pawn_captures": lambda self: True})()
 
     assert policy.next_turn_has_pawn_capture(fake_game) is True
+    assert policy.next_turn_pawn_tries(fake_game) is None
+
+
+def test_ruleset_policy_announces_pawn_try_squares_for_rand():
+    policy = resolve_ruleset_policy(ruleset=RULESET_RAND)
+    fake_game = type(
+        "FakeGame",
+        (),
+        {
+            "game_over": False,
+            "_legal_pawn_capture_source_squares": lambda self: (chess.E4,),
+        },
+    )()
+
+    assert policy.next_turn_pawn_try_squares(fake_game) == (chess.E4,)
+    assert policy.next_turn_has_pawn_capture(fake_game) is None
     assert policy.next_turn_pawn_tries(fake_game) is None

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -621,7 +621,7 @@ class TestBerkeleyGameSerializer:
             next_turn_pawn_try_squares=(chess.E4,),
         )
 
-    def test_rand_roundtrip_preserves_promotion_announcement(self):
+    def test_rand_serialization_writes_promotion_announcement(self):
         game = BerkeleyGame(ruleset=RULESET_RAND)
         game._board.clear()
         game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
@@ -630,10 +630,10 @@ class TestBerkeleyGameSerializer:
         game._generate_possible_to_ask_list()
         game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move(chess.H7, chess.H8, promotion=chess.QUEEN)))
         serialized = serialize_berkeley_game(game)
-        deserialized = deserialize_berkeley_game(serialized)
+        answer_data = serialized["game_state"]["white_scoresheet"]["moves_own"][0][0][1]
 
-        assert deserialized.ruleset_id == RULESET_RAND
-        assert deserialized._whites_scoresheet.moves_own[0][0][1] == KriegspielAnswer(
+        assert serialized["game_state"]["ruleset_id"] == RULESET_RAND
+        assert deserialize_kriegspiel_answer(answer_data) == KriegspielAnswer(
             MainAnnouncement.REGULAR_MOVE,
             promotion_announced=True,
             next_turn_pawn_try_squares=tuple(),

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -28,6 +28,7 @@ from kriegspiel.serialization import (
 from kriegspiel.rulesets import RULESET_BERKELEY
 from kriegspiel.rulesets import RULESET_BERKELEY_ANY
 from kriegspiel.rulesets import RULESET_CINCINNATI
+from kriegspiel.rulesets import RULESET_RAND
 from kriegspiel.rulesets import RULESET_WILD16
 
 
@@ -100,6 +101,8 @@ class TestEnumSerializer:
             (SpecialCaseAnnouncement.NONE, deserialize_special_case_announcement),
             (SpecialCaseAnnouncement.CHECK_RANK, deserialize_special_case_announcement),
             (SpecialCaseAnnouncement.CHECKMATE_WHITE_WINS, deserialize_special_case_announcement),
+            (SpecialCaseAnnouncement.STALEMATE_WHITE_WINS, deserialize_special_case_announcement),
+            (SpecialCaseAnnouncement.STALEMATE_BLACK_WINS, deserialize_special_case_announcement),
         ]
         
         for enum_val, deserializer in enums_to_test:
@@ -331,6 +334,44 @@ class TestKriegspielAnswerSerializer:
             MainAnnouncement.REGULAR_MOVE,
             next_turn_has_pawn_capture=False,
         )
+
+    def test_serialize_rand_answer_fields(self):
+        answer = KriegspielAnswer(
+            MainAnnouncement.REGULAR_MOVE,
+            promotion_announced=True,
+            next_turn_pawn_try_squares=[chess.E4, chess.C2, chess.E4],
+        )
+
+        assert serialize_kriegspiel_answer(answer) == {
+            "main_announcement": "REGULAR_MOVE",
+            "capture_at_square": None,
+            "captured_piece_announcement": None,
+            "special_announcement": "NONE",
+            "next_turn_pawn_tries": None,
+            "check_1": None,
+            "check_2": None,
+            "promotion_announced": True,
+            "next_turn_pawn_try_squares": [chess.C2, chess.E4],
+        }
+
+    def test_deserialize_rand_answer_fields(self):
+        data = {
+            "main_announcement": "REGULAR_MOVE",
+            "capture_at_square": None,
+            "captured_piece_announcement": None,
+            "special_announcement": "NONE",
+            "next_turn_pawn_tries": None,
+            "check_1": None,
+            "check_2": None,
+            "promotion_announced": True,
+            "next_turn_pawn_try_squares": [chess.E4, chess.C2],
+        }
+
+        assert deserialize_kriegspiel_answer(data) == KriegspielAnswer(
+            MainAnnouncement.REGULAR_MOVE,
+            promotion_announced=True,
+            next_turn_pawn_try_squares=(chess.C2, chess.E4),
+        )
     
     def test_kriegspiel_answer_roundtrip(self):
         answers = [
@@ -347,6 +388,8 @@ class TestKriegspielAnswerSerializer:
             KriegspielAnswer(MainAnnouncement.HAS_ANY),
             KriegspielAnswer(MainAnnouncement.NO_ANY),
             KriegspielAnswer(MainAnnouncement.REGULAR_MOVE, next_turn_has_pawn_capture=True),
+            KriegspielAnswer(MainAnnouncement.REGULAR_MOVE, next_turn_pawn_try_squares=(chess.E4,)),
+            KriegspielAnswer(MainAnnouncement.REGULAR_MOVE, promotion_announced=True),
         ]
         
         for answer in answers:
@@ -456,6 +499,13 @@ class TestBerkeleyGameSerializer:
 
         assert result["game_state"]["ruleset_id"] == RULESET_CINCINNATI
         assert result["game_state"]["any_rule"] is False
+
+    def test_serialize_rand_game(self):
+        game = BerkeleyGame(ruleset=RULESET_RAND)
+        result = serialize_berkeley_game(game)
+
+        assert result["game_state"]["ruleset_id"] == RULESET_RAND
+        assert result["game_state"]["any_rule"] is False
     
     def test_serialize_game_with_moves(self):
         game = BerkeleyGame(any_rule=True)
@@ -554,6 +604,39 @@ class TestBerkeleyGameSerializer:
         assert deserialized._whites_scoresheet.moves_opponent[0][0][1] == KriegspielAnswer(
             MainAnnouncement.REGULAR_MOVE,
             next_turn_has_pawn_capture=True,
+        )
+
+    def test_rand_roundtrip_preserves_public_rebuffs_and_pawn_try_squares(self):
+        game = BerkeleyGame(ruleset=RULESET_RAND)
+        game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move.from_uci("e3e4")))
+        game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move.from_uci("e2e4")))
+        game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move.from_uci("d7d5")))
+        serialized = serialize_berkeley_game(game)
+        deserialized = deserialize_berkeley_game(serialized)
+
+        assert deserialized.ruleset_id == RULESET_RAND
+        assert deserialized._whites_scoresheet.moves_own[0][0][1] == KriegspielAnswer(MainAnnouncement.NONSENSE)
+        assert deserialized._whites_scoresheet.moves_opponent[0][0][1] == KriegspielAnswer(
+            MainAnnouncement.REGULAR_MOVE,
+            next_turn_pawn_try_squares=(chess.E4,),
+        )
+
+    def test_rand_roundtrip_preserves_promotion_announcement(self):
+        game = BerkeleyGame(ruleset=RULESET_RAND)
+        game._board.clear()
+        game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+        game._board.set_piece_at(chess.H7, chess.Piece(chess.PAWN, chess.WHITE))
+        game._board.set_piece_at(chess.A4, chess.Piece(chess.KING, chess.BLACK))
+        game._generate_possible_to_ask_list()
+        game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move(chess.H7, chess.H8, promotion=chess.QUEEN)))
+        serialized = serialize_berkeley_game(game)
+        deserialized = deserialize_berkeley_game(serialized)
+
+        assert deserialized.ruleset_id == RULESET_RAND
+        assert deserialized._whites_scoresheet.moves_own[0][0][1] == KriegspielAnswer(
+            MainAnnouncement.REGULAR_MOVE,
+            promotion_announced=True,
+            next_turn_pawn_try_squares=tuple(),
         )
 
     def test_deserialize_rejects_missing_move_stack(self):


### PR DESCRIPTION
## What changed

- Adds first-class RAND ruleset support to the shared hidden-board engine via `RULESET_RAND` and `RandGame`.
- Adds RAND-specific referee behavior: public rebuffs, typed pawn/piece capture announcements, promotion notices, pawn-try source-square announcements, and RAND ladder stalemate-as-loss handling.
- Extends `KriegspielAnswer` and JSON schema `7` with `promotion_announced` and `next_turn_pawn_try_squares`, while keeping schemas `3` through `6` readable.
- Updates README, package metadata, and release notes for version `1.5.0`.

## Why

RAND rules are now published on the site as a reference ruleset, and the engine needs native support before backend/frontend integration can use the same referee model without ruleset spillover.

## Testing

- Not run locally by design; project workflow requires tests on the remote host.
- Remote validation on `rpis02-cf` is pending and will be added as a PR comment.

## Deployment notes

- This changes the Python package API and bumps `kriegspiel` to `1.5.0`.
- Downstream backend/frontend support can consume `RandGame`, `ruleset='rand'`, and the new answer metadata after this is released.
