### PR TITLE
Add English ruleset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Current scope:
 - Berkeley Kriegspiel
 - Berkeley + Any
 - Cincinnati
+- English
 - RAND
 - Wild 16
 
@@ -47,13 +48,16 @@ loaded = KriegspielGame.load_game("game.json")
 still use `BerkeleyGame` explicitly as a compatibility wrapper, or pick a ruleset
 with `ruleset=...`.
 
-Cincinnati, RAND, and Wild 16 also have their own convenience entrypoints:
+Cincinnati, English, RAND, and Wild 16 also have their own convenience entrypoints:
 
 ```python
-from kriegspiel import CincinnatiGame, RandGame, Wild16Game
+from kriegspiel import CincinnatiGame, EnglishGame, RandGame, Wild16Game
 
 cincinnati = CincinnatiGame()
 print(cincinnati.current_turn_has_pawn_capture)
+
+english = EnglishGame()
+print(english.any_rule)
 
 rand = RandGame()
 print(rand.current_turn_pawn_try_squares)
@@ -67,6 +71,7 @@ print(wild16.current_turn_pawn_tries)
 - `KriegspielGame`: the neutral public entrypoint for the shared hidden-board engine
 - `BerkeleyGame`: backward-compatible Berkeley-named wrapper over `KriegspielGame`
 - `CincinnatiGame`: Cincinnati convenience entrypoint with public `NONSENSE` and binary pawn-capture announcements
+- `EnglishGame`: English convenience entrypoint with public illegal attempts and one-try `ASK_ANY` handling
 - `RandGame`: RAND convenience entrypoint with public rebuffs, pawn-try source-square announcements, typed captures, and promotion notices
 - `Wild16Game`: Wild 16 convenience entrypoint over the shared hidden-board engine
 - `KriegspielMove`: a player question, either a normal move or `ASK_ANY`

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## Kriegspiel v. 1.6.0
+
+- **English Support**: added first-class `english` ruleset handling plus a dedicated `kriegspiel.english.EnglishGame` convenience entrypoint.
+- **English Any? Rule**: supports the English “Any?” question, where a positive answer requires one pawn-capture try and then releases the player if that try is illegal.
+- **Referee Announcements**: English illegal attempts are public, captures announce the square without pawn-vs-piece identity, promotions remain silent, and stalemate remains a draw.
+- **Testing**: added focused English engine, serialization, and rules-comparison coverage while keeping branch coverage expectations intact.
+
 ## Kriegspiel v. 1.5.0
 
 - **RAND Support**: added first-class `rand` ruleset handling plus a dedicated `kriegspiel.rand.RandGame` convenience entrypoint.

--- a/kriegspiel/__init__.py
+++ b/kriegspiel/__init__.py
@@ -4,10 +4,11 @@ __author__ = "Alexander Filatov"
 
 __email__ = "alexander@kriegspiel.org"
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 
 from kriegspiel.berkeley import BerkeleyGame
 from kriegspiel.cincinnati import CincinnatiGame
+from kriegspiel.english import EnglishGame
 from kriegspiel.game import KriegspielGame
 from kriegspiel.move import CapturedPieceAnnouncement
 from kriegspiel.move import KriegspielAnswer
@@ -28,6 +29,7 @@ __all__ = [
     "BerkeleyGameSnapshot",
     "CincinnatiGame",
     "CapturedPieceAnnouncement",
+    "EnglishGame",
     "KriegspielAnswer",
     "KriegspielGame",
     "KriegspielGameSnapshot",

--- a/kriegspiel/english.py
+++ b/kriegspiel/english.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+"""Convenience entrypoint for the English Kriegspiel ruleset."""
+
+from __future__ import annotations
+
+from kriegspiel.game import KriegspielGame
+from kriegspiel.move import KriegspielScoresheet as KSSS
+from kriegspiel.rulesets import RULESET_ENGLISH
+from kriegspiel.serialization import load_game_from_json
+
+
+class EnglishGame(KriegspielGame):
+    """English convenience wrapper over the shared hidden-board engine."""
+
+    def __init__(self):
+        super().__init__(ruleset=RULESET_ENGLISH)
+
+    @classmethod
+    def _from_kriegspiel_game(cls, game):
+        """Rebuild an EnglishGame wrapper from a validated shared-engine instance."""
+        if not isinstance(game, KriegspielGame):
+            raise TypeError("game must be a KriegspielGame")
+        if game.ruleset_id != RULESET_ENGLISH:
+            raise ValueError("game must use the english ruleset")
+
+        instance = cls()
+        instance._board = game._board.copy(stack=True)
+        instance._must_use_pawns = game._must_use_pawns
+        instance._game_over = game._game_over
+        instance._possible_to_ask = list(game.possible_to_ask)
+        instance._possible_to_ask_set = set(game.possible_to_ask)
+        instance._whites_scoresheet = KSSS.from_snapshot(game._whites_scoresheet.snapshot())
+        instance._blacks_scoresheet = KSSS.from_snapshot(game._blacks_scoresheet.snapshot())
+        return instance
+
+    @classmethod
+    def from_snapshot(cls, snapshot):
+        """Build an EnglishGame from a validated snapshot."""
+        return cls._from_kriegspiel_game(KriegspielGame.from_snapshot(snapshot))
+
+    @classmethod
+    def load_game(cls, filename):
+        """Load an English game from disk."""
+        return cls._from_kriegspiel_game(load_game_from_json(filename))

--- a/kriegspiel/game.py
+++ b/kriegspiel/game.py
@@ -26,11 +26,11 @@ class KriegspielGame(object):
     """
     Shared hidden-board Kriegspiel referee engine.
 
-    Ruleset-specific behavior such as Berkeley `ASK_ANY`, Cincinnati binary
-    pawn-capture announcements, RAND pawn-try source squares, or Wild 16
-    pawn-try counts is delegated to a policy layer. Variant-named wrappers like
-    `BerkeleyGame`, `CincinnatiGame`, `RandGame`, and `Wild16Game` build on this
-    class.
+    Ruleset-specific behavior such as Berkeley `ASK_ANY`, English one-try
+    `ASK_ANY`, Cincinnati binary pawn-capture announcements, RAND pawn-try
+    source squares, or Wild 16 pawn-try counts is delegated to a policy layer.
+    Variant-named wrappers like `BerkeleyGame`, `EnglishGame`, `CincinnatiGame`,
+    `RandGame`, and `Wild16Game` build on this class.
 
     Communication with this class must be in the form of questions —
     KriegspielMove(s) with QuestionAnnouncement(s).
@@ -47,8 +47,8 @@ class KriegspielGame(object):
             any_rule: Legacy compatibility flag for Berkeley+Any. When omitted,
                      Berkeley+Any remains the default.
             ruleset: Explicit ruleset identifier. Supported values are
-                     `berkeley`, `berkeley_any`, `cincinnati`, `rand`, and
-                     `wild16`.
+                     `berkeley`, `berkeley_any`, `cincinnati`, `english`,
+                     `rand`, and `wild16`.
         """
         super().__init__()
         self._ruleset = resolve_ruleset_policy(ruleset=ruleset, any_rule=any_rule)
@@ -109,7 +109,7 @@ class KriegspielGame(object):
         """
         if move.question_type == QA.COMMON:
             if move not in self._possible_to_ask_set:
-                return KSAnswer(self._ruleset.classify_impossible_common_attempt())
+                return KSAnswer(self._ruleset.classify_impossible_common_attempt(self))
             # Player asks about a common move
             if self._is_legal_move(move.chess_move):
                 # Move is legal in normal chess

--- a/kriegspiel/rulesets.py
+++ b/kriegspiel/rulesets.py
@@ -16,6 +16,7 @@ from kriegspiel.move import QuestionAnnouncement as QA
 RULESET_BERKELEY = "berkeley"
 RULESET_BERKELEY_ANY = "berkeley_any"
 RULESET_CINCINNATI = "cincinnati"
+RULESET_ENGLISH = "english"
 RULESET_RAND = "rand"
 RULESET_WILD16 = "wild16"
 
@@ -27,7 +28,7 @@ class BerkeleyRulesetPolicy:
     The hidden-board move engine is shared, while this policy decides
     which referee-only questions exist and how those questions constrain
     the next prompt. This keeps the current Berkeley behavior intact while
-    making Cincinnati / Wild 16 style variants easier to add.
+    making ruleset variants easier to add without forking the engine.
     """
 
     identifier: str
@@ -40,6 +41,7 @@ class BerkeleyRulesetPolicy:
     announce_next_turn_pawn_tries: bool
     announce_next_turn_has_pawn_capture: bool
     announce_next_turn_pawn_try_squares: bool
+    release_ask_any_after_failed_pawn_try: bool
     stalemate_loses: bool
 
     def add_special_questions(self, possibilities: set[KSMove]) -> None:
@@ -62,7 +64,9 @@ class BerkeleyRulesetPolicy:
             }
         return pawn_captures
 
-    def classify_impossible_common_attempt(self) -> MA:
+    def classify_impossible_common_attempt(self, game=None) -> MA:
+        if game is not None and game.must_use_pawns:
+            return MA.IMPOSSIBLE_TO_ASK
         return self.invalid_common_attempt_result
 
     def handle_special_question(self, game, move: KSMove):
@@ -76,6 +80,10 @@ class BerkeleyRulesetPolicy:
         return KSAnswer(MA.NO_ANY)
 
     def apply_post_answer_constraints(self, game, answer: KSAnswer) -> None:
+        if self.release_ask_any_after_failed_pawn_try and game.must_use_pawns and answer.main_announcement == MA.ILLEGAL_MOVE:
+            game._must_use_pawns = False
+            game._generate_possible_to_ask_list()
+            return
         if not self.allow_ask_any:
             return
         if answer.main_announcement == MA.HAS_ANY:
@@ -128,7 +136,7 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
         allow_ask_any = True if any_rule is None else any_rule
         ruleset = RULESET_BERKELEY_ANY if allow_ask_any else RULESET_BERKELEY
     elif any_rule is not None:
-        expected_any_rule = ruleset == RULESET_BERKELEY_ANY
+        expected_any_rule = ruleset in {RULESET_BERKELEY_ANY, RULESET_ENGLISH}
         if expected_any_rule != any_rule:
             raise ValueError(
                 f"ruleset {ruleset!r} conflicts with any_rule={any_rule!r}"
@@ -146,6 +154,7 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             announce_next_turn_pawn_tries=False,
             announce_next_turn_has_pawn_capture=False,
             announce_next_turn_pawn_try_squares=False,
+            release_ask_any_after_failed_pawn_try=False,
             stalemate_loses=False,
         )
     if ruleset == RULESET_BERKELEY:
@@ -160,6 +169,7 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             announce_next_turn_pawn_tries=False,
             announce_next_turn_has_pawn_capture=False,
             announce_next_turn_pawn_try_squares=False,
+            release_ask_any_after_failed_pawn_try=False,
             stalemate_loses=False,
         )
     if ruleset == RULESET_CINCINNATI:
@@ -174,6 +184,22 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             announce_next_turn_pawn_tries=False,
             announce_next_turn_has_pawn_capture=True,
             announce_next_turn_pawn_try_squares=False,
+            release_ask_any_after_failed_pawn_try=False,
+            stalemate_loses=False,
+        )
+    if ruleset == RULESET_ENGLISH:
+        return BerkeleyRulesetPolicy(
+            identifier=ruleset,
+            allow_ask_any=True,
+            invalid_common_attempt_result=MA.ILLEGAL_MOVE,
+            discard_illegal_attempts=True,
+            public_illegal_attempts=True,
+            typed_capture_announcements=False,
+            announce_promotion=False,
+            announce_next_turn_pawn_tries=False,
+            announce_next_turn_has_pawn_capture=False,
+            announce_next_turn_pawn_try_squares=False,
+            release_ask_any_after_failed_pawn_try=True,
             stalemate_loses=False,
         )
     if ruleset == RULESET_RAND:
@@ -188,6 +214,7 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             announce_next_turn_pawn_tries=False,
             announce_next_turn_has_pawn_capture=False,
             announce_next_turn_pawn_try_squares=True,
+            release_ask_any_after_failed_pawn_try=False,
             stalemate_loses=True,
         )
     if ruleset == RULESET_WILD16:
@@ -202,6 +229,7 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             announce_next_turn_pawn_tries=True,
             announce_next_turn_has_pawn_capture=False,
             announce_next_turn_pawn_try_squares=False,
+            release_ask_any_after_failed_pawn_try=False,
             stalemate_loses=False,
         )
     raise ValueError(f"Unsupported ruleset: {ruleset!r}")

--- a/kriegspiel/serialization.py
+++ b/kriegspiel/serialization.py
@@ -9,7 +9,7 @@ Kriegspiel game components using JSON format with custom encoders/decoders.
 JSON Schema Structure:
 {
   "schema_version": 7,
-  "library_version": "1.5.0",
+  "library_version": "1.6.0",
   "game_type": "BerkeleyGame",
   "game_state": {
     "ruleset_id": "berkeley_any",

--- a/tests/test_english.py
+++ b/tests/test_english.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+
+"""English-specific engine and convenience entrypoint tests."""
+
+import os
+import tempfile
+
+import pytest
+
+from kriegspiel.berkeley import BerkeleyGame, chess
+from kriegspiel.english import EnglishGame
+from kriegspiel.move import KriegspielAnswer as KSAnswer
+from kriegspiel.move import KriegspielMove as KSMove
+from kriegspiel.move import MainAnnouncement as MA
+from kriegspiel.move import QuestionAnnouncement as QA
+from kriegspiel.move import SpecialCaseAnnouncement as SCA
+from kriegspiel.rulesets import RULESET_ENGLISH, resolve_ruleset_policy
+
+
+def _build_english_any_game():
+    game = EnglishGame()
+    game._board.clear()
+    game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.A1, chess.Piece(chess.ROOK, chess.WHITE))
+    game._board.set_piece_at(chess.E4, chess.Piece(chess.PAWN, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.A5, chess.Piece(chess.KNIGHT, chess.BLACK))
+    game._board.set_piece_at(chess.D5, chess.Piece(chess.BISHOP, chess.BLACK))
+    game._generate_possible_to_ask_list()
+    return game
+
+
+def test_english_game_uses_english_ruleset():
+    game = EnglishGame()
+
+    assert game.ruleset_id == RULESET_ENGLISH
+    assert game.any_rule is True
+    assert KSMove(QA.ASK_ANY) in game.possible_to_ask
+    assert game.current_turn_has_pawn_capture is None
+    assert game.current_turn_pawn_tries is None
+    assert game.current_turn_pawn_try_squares is None
+
+
+def test_english_policy_uses_public_illegal_attempts_and_untyped_captures():
+    policy = resolve_ruleset_policy(ruleset=RULESET_ENGLISH)
+
+    assert policy.classify_impossible_common_attempt() == MA.ILLEGAL_MOVE
+    assert policy.public_illegal_attempts is True
+    assert policy.discard_illegal_attempts is True
+    assert policy.typed_capture_announcements is False
+    assert policy.announce_promotion is False
+    assert policy.release_ask_any_after_failed_pawn_try is True
+    assert policy.captured_piece_announcement_for(chess.Piece(chess.PAWN, chess.BLACK)) is None
+
+
+def test_english_any_no_allows_regular_move_without_public_metadata():
+    game = EnglishGame()
+
+    assert game.ask_for(KSMove(QA.ASK_ANY)) == KSAnswer(MA.NO_ANY)
+    assert game.must_use_pawns is False
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e2e4"))) == KSAnswer(MA.REGULAR_MOVE)
+
+
+def test_english_any_yes_requires_one_pawn_try_before_other_moves():
+    game = _build_english_any_game()
+    rook_move = KSMove(QA.COMMON, chess.Move(chess.A1, chess.A5))
+
+    assert game.ask_for(KSMove(QA.ASK_ANY)) == KSAnswer(MA.HAS_ANY)
+    assert game.must_use_pawns is True
+    assert game.ask_for(rook_move) == KSAnswer(MA.IMPOSSIBLE_TO_ASK)
+    assert game.must_use_pawns is True
+
+
+def test_english_failed_pawn_try_releases_any_obligation():
+    game = _build_english_any_game()
+    empty_pawn_try = KSMove(QA.COMMON, chess.Move(chess.E4, chess.F5))
+    rook_move = KSMove(QA.COMMON, chess.Move(chess.A1, chess.A5))
+
+    assert game.ask_for(KSMove(QA.ASK_ANY)) == KSAnswer(MA.HAS_ANY)
+    assert game.ask_for(empty_pawn_try) == KSAnswer(MA.ILLEGAL_MOVE)
+    assert game.must_use_pawns is False
+    assert rook_move in game.possible_to_ask
+    assert empty_pawn_try not in game.possible_to_ask
+
+
+def test_english_legal_pawn_capture_after_any_completes_move():
+    game = _build_english_any_game()
+
+    assert game.ask_for(KSMove(QA.ASK_ANY)) == KSAnswer(MA.HAS_ANY)
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move(chess.E4, chess.D5))) == KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.D5,
+    )
+
+
+def test_english_capture_announces_square_but_not_captured_kind():
+    game = _build_english_any_game()
+
+    result = game.ask_for(KSMove(QA.COMMON, chess.Move(chess.A1, chess.A5)))
+
+    assert result == KSAnswer(MA.CAPTURE_DONE, capture_at_square=chess.A5)
+    assert result.captured_piece_announcement is None
+
+
+def test_english_public_illegal_attempt_is_visible_to_opponent():
+    game = EnglishGame()
+    game._board.clear()
+    game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.A1, chess.Piece(chess.ROOK, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.A3, chess.Piece(chess.KNIGHT, chess.BLACK))
+    game._generate_possible_to_ask_list()
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move(chess.A1, chess.A5))) == KSAnswer(MA.ILLEGAL_MOVE)
+    assert game._blacks_scoresheet.moves_opponent[0][0][1] == KSAnswer(MA.ILLEGAL_MOVE)
+
+
+def test_english_impossible_common_attempt_is_public_illegal_outside_any_obligation():
+    game = EnglishGame()
+    impossible = KSMove(QA.COMMON, chess.Move.from_uci("e2e5"))
+
+    assert game.ask_for(impossible) == KSAnswer(MA.ILLEGAL_MOVE)
+    assert game._whites_scoresheet.moves_own[0][0][1] == KSAnswer(MA.ILLEGAL_MOVE)
+    assert game._blacks_scoresheet.moves_opponent[0][0][1] == KSAnswer(MA.ILLEGAL_MOVE)
+
+
+def test_english_promotion_is_silent():
+    game = EnglishGame()
+    game._board.clear()
+    game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.H7, chess.Piece(chess.PAWN, chess.WHITE))
+    game._board.set_piece_at(chess.A4, chess.Piece(chess.KING, chess.BLACK))
+    game._generate_possible_to_ask_list()
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move(chess.H7, chess.H8, promotion=chess.QUEEN))) == KSAnswer(
+        MA.REGULAR_MOVE
+    )
+
+
+def test_english_stalemate_remains_draw():
+    game = EnglishGame()
+    game._board.clear()
+    game._board.set_piece_at(chess.F7, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.G5, chess.Piece(chess.QUEEN, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._generate_possible_to_ask_list()
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move(chess.G5, chess.G6))) == KSAnswer(
+        MA.REGULAR_MOVE,
+        special_announcement=SCA.DRAW_STALEMATE,
+    )
+
+
+def test_english_from_snapshot_returns_variant_instance():
+    game = EnglishGame()
+    game.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+
+    restored = EnglishGame.from_snapshot(game.snapshot())
+
+    assert isinstance(restored, EnglishGame)
+    assert restored.ruleset_id == RULESET_ENGLISH
+    assert restored._board.fen() == game._board.fen()
+
+
+def test_english_from_snapshot_rejects_other_ruleset():
+    game = BerkeleyGame(any_rule=False)
+
+    with pytest.raises(ValueError, match="english ruleset"):
+        EnglishGame.from_snapshot(game.snapshot())
+
+
+def test_english_private_helper_rejects_non_game():
+    with pytest.raises(TypeError, match="KriegspielGame"):
+        EnglishGame._from_kriegspiel_game("not-a-game")
+
+
+def test_english_load_game_returns_variant_instance():
+    game = EnglishGame()
+    game.ask_for(KSMove(QA.COMMON, chess.Move(chess.E2, chess.E4)))
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as handle:
+        filename = handle.name
+
+    try:
+        game.save_game(filename)
+        restored = EnglishGame.load_game(filename)
+    finally:
+        os.unlink(filename)
+
+    assert isinstance(restored, EnglishGame)
+    assert restored.ruleset_id == RULESET_ENGLISH
+    assert restored._board.fen() == game._board.fen()
+
+
+def test_english_load_game_rejects_other_ruleset():
+    game = BerkeleyGame(any_rule=False)
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as handle:
+        filename = handle.name
+
+    try:
+        game.save_game(filename)
+        with pytest.raises(ValueError, match="english ruleset"):
+            EnglishGame.load_game(filename)
+    finally:
+        os.unlink(filename)

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -10,6 +10,7 @@ import pytest
 
 from kriegspiel import BerkeleyGame
 from kriegspiel import CincinnatiGame
+from kriegspiel import EnglishGame
 from kriegspiel import KriegspielGame
 from kriegspiel import KriegspielMove as KSMove
 from kriegspiel import MainAnnouncement as MA
@@ -114,9 +115,10 @@ def test_move_stack_from_scoresheets_handles_black_only_turns():
     [
         pytest.param(BerkeleyGame(), id="berkeley-any"),
         pytest.param(BerkeleyGame(any_rule=False), id="berkeley"),
+        pytest.param(EnglishGame(), id="english"),
     ],
 )
-def test_public_material_summary_hides_pawn_capture_counts_for_berkeley_family(game):
+def test_public_material_summary_hides_pawn_capture_counts_for_untyped_rulesets(game):
     game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e2e4")))
     game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("d7d5")))
     game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e4d5")))
@@ -277,6 +279,7 @@ def test_package_root_exports_variant_entrypoints():
     assert KriegspielGame.__name__ == "KriegspielGame"
     assert BerkeleyGame.__name__ == "BerkeleyGame"
     assert CincinnatiGame.__name__ == "CincinnatiGame"
+    assert EnglishGame.__name__ == "EnglishGame"
     assert RandGame.__name__ == "RandGame"
     assert Wild16Game.__name__ == "Wild16Game"
     assert MaterialSideSummary.__name__ == "MaterialSideSummary"

--- a/tests/test_rules_comparison.py
+++ b/tests/test_rules_comparison.py
@@ -6,6 +6,7 @@ import pytest
 
 from kriegspiel.berkeley import BerkeleyGame, chess
 from kriegspiel.cincinnati import CincinnatiGame
+from kriegspiel.english import EnglishGame
 from kriegspiel.move import CapturedPieceAnnouncement as CPA
 from kriegspiel.move import KriegspielAnswer as KSAnswer
 from kriegspiel.move import KriegspielMove as KSMove
@@ -63,12 +64,14 @@ def test_rules_comparison_position_announces_ruleset_specific_pawn_capture_metad
     berkeley_any = _build_rules_comparison_game(BerkeleyGame())
     berkeley = _build_rules_comparison_game(BerkeleyGame(any_rule=False))
     cincinnati = _build_rules_comparison_game(CincinnatiGame())
+    english = _build_rules_comparison_game(EnglishGame())
     rand = _build_rules_comparison_game(RandGame())
     wild16 = _build_rules_comparison_game(Wild16Game())
 
     assert KSMove(QA.ASK_ANY) in berkeley_any.possible_to_ask
     assert KSMove(QA.ASK_ANY) not in berkeley.possible_to_ask
     assert KSMove(QA.ASK_ANY) not in cincinnati.possible_to_ask
+    assert KSMove(QA.ASK_ANY) in english.possible_to_ask
     assert KSMove(QA.ASK_ANY) not in rand.possible_to_ask
     assert KSMove(QA.ASK_ANY) not in wild16.possible_to_ask
 
@@ -78,6 +81,9 @@ def test_rules_comparison_position_announces_ruleset_specific_pawn_capture_metad
     assert berkeley.current_turn_pawn_tries is None
     assert cincinnati.current_turn_has_pawn_capture is True
     assert cincinnati.current_turn_pawn_tries is None
+    assert english.current_turn_has_pawn_capture is None
+    assert english.current_turn_pawn_tries is None
+    assert english.current_turn_pawn_try_squares is None
     assert rand.current_turn_has_pawn_capture is None
     assert rand.current_turn_pawn_tries is None
     assert rand.current_turn_pawn_try_squares == (chess.E4,)
@@ -92,6 +98,7 @@ def test_rules_comparison_position_announces_ruleset_specific_pawn_capture_metad
         pytest.param(BerkeleyGame(), None, None, id="berkeley-any"),
         pytest.param(BerkeleyGame(any_rule=False), None, None, id="berkeley"),
         pytest.param(CincinnatiGame(), True, None, id="cincinnati"),
+        pytest.param(EnglishGame(), None, None, id="english"),
         pytest.param(RandGame(), None, None, id="rand"),
         pytest.param(Wild16Game(), None, 1, id="wild16"),
     ],
@@ -126,6 +133,11 @@ def test_rules_comparison_promotion_capture_counts_as_one_pawn_capture(
             BerkeleyGame(any_rule=False),
             KSAnswer(MA.CAPTURE_DONE, capture_at_square=chess.A5),
             id="berkeley",
+        ),
+        pytest.param(
+            EnglishGame(),
+            KSAnswer(MA.CAPTURE_DONE, capture_at_square=chess.A5),
+            id="english",
         ),
         pytest.param(
             CincinnatiGame(),
@@ -181,9 +193,10 @@ def test_rules_comparison_berkeley_any_has_any_forces_a_pawn_capture():
     [
         pytest.param(BerkeleyGame(), id="berkeley-any"),
         pytest.param(BerkeleyGame(any_rule=False), id="berkeley"),
+        pytest.param(EnglishGame(), id="english"),
     ],
 )
-def test_rules_comparison_berkeley_family_can_try_pawn_captures_without_announcement(game):
+def test_rules_comparison_ask_any_rulesets_can_try_pawn_captures_without_announcement(game):
     game = _build_rules_comparison_game(game)
 
     assert _left_pawn_capture_move() in game.possible_to_ask

--- a/tests/test_rulesets.py
+++ b/tests/test_rulesets.py
@@ -3,6 +3,7 @@
 """Focused policy tests for shared ruleset behavior."""
 
 import chess
+import pytest
 
 from kriegspiel.move import CapturedPieceAnnouncement as CPA
 from kriegspiel.move import KriegspielAnswer as KSAnswer
@@ -12,6 +13,7 @@ from kriegspiel.move import QuestionAnnouncement as QA
 from kriegspiel.rulesets import RULESET_BERKELEY
 from kriegspiel.rulesets import RULESET_BERKELEY_ANY
 from kriegspiel.rulesets import RULESET_CINCINNATI
+from kriegspiel.rulesets import RULESET_ENGLISH
 from kriegspiel.rulesets import RULESET_RAND
 from kriegspiel.rulesets import RULESET_WILD16
 from kriegspiel.rulesets import resolve_ruleset_policy
@@ -21,7 +23,13 @@ def test_resolve_ruleset_policy_accepts_matching_any_rule_flags():
     assert resolve_ruleset_policy(ruleset=RULESET_BERKELEY_ANY, any_rule=True).identifier == RULESET_BERKELEY_ANY
     assert resolve_ruleset_policy(ruleset=RULESET_BERKELEY, any_rule=False).identifier == RULESET_BERKELEY
     assert resolve_ruleset_policy(ruleset=RULESET_CINCINNATI, any_rule=False).identifier == RULESET_CINCINNATI
+    assert resolve_ruleset_policy(ruleset=RULESET_ENGLISH, any_rule=True).identifier == RULESET_ENGLISH
     assert resolve_ruleset_policy(ruleset=RULESET_RAND, any_rule=False).identifier == RULESET_RAND
+
+
+def test_resolve_ruleset_policy_rejects_conflicting_english_any_rule_flag():
+    with pytest.raises(ValueError, match="conflicts"):
+        resolve_ruleset_policy(ruleset=RULESET_ENGLISH, any_rule=False)
 
 
 def test_ruleset_policy_controls_opponent_visibility():
@@ -33,6 +41,13 @@ def test_ruleset_policy_controls_opponent_visibility():
     assert public_policy.should_record_opponent_answer(move, KSAnswer(MA.ILLEGAL_MOVE)) is True
     assert private_policy.should_record_opponent_answer(move, KSAnswer(MA.ILLEGAL_MOVE)) is False
     assert private_policy.should_record_opponent_answer(move, KSAnswer(MA.REGULAR_MOVE)) is True
+
+
+def test_ruleset_policy_rejects_non_pawn_moves_during_ask_any_obligation():
+    policy = resolve_ruleset_policy(ruleset=RULESET_ENGLISH)
+    fake_game = type("FakeGame", (), {"must_use_pawns": True})()
+
+    assert policy.classify_impossible_common_attempt(fake_game) == MA.IMPOSSIBLE_TO_ASK
 
 
 def test_ruleset_policy_announces_piece_captures_for_wild16():

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -28,6 +28,7 @@ from kriegspiel.serialization import (
 from kriegspiel.rulesets import RULESET_BERKELEY
 from kriegspiel.rulesets import RULESET_BERKELEY_ANY
 from kriegspiel.rulesets import RULESET_CINCINNATI
+from kriegspiel.rulesets import RULESET_ENGLISH
 from kriegspiel.rulesets import RULESET_RAND
 from kriegspiel.rulesets import RULESET_WILD16
 
@@ -500,6 +501,13 @@ class TestBerkeleyGameSerializer:
         assert result["game_state"]["ruleset_id"] == RULESET_CINCINNATI
         assert result["game_state"]["any_rule"] is False
 
+    def test_serialize_english_game(self):
+        game = BerkeleyGame(ruleset=RULESET_ENGLISH)
+        result = serialize_berkeley_game(game)
+
+        assert result["game_state"]["ruleset_id"] == RULESET_ENGLISH
+        assert result["game_state"]["any_rule"] is True
+
     def test_serialize_rand_game(self):
         game = BerkeleyGame(ruleset=RULESET_RAND)
         result = serialize_berkeley_game(game)
@@ -605,6 +613,16 @@ class TestBerkeleyGameSerializer:
             MainAnnouncement.REGULAR_MOVE,
             next_turn_has_pawn_capture=True,
         )
+
+    def test_english_roundtrip_preserves_any_state(self):
+        game = BerkeleyGame(ruleset=RULESET_ENGLISH)
+        game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move.from_uci("e2e4")))
+        serialized = serialize_berkeley_game(game)
+        deserialized = deserialize_berkeley_game(serialized)
+
+        assert deserialized.ruleset_id == RULESET_ENGLISH
+        assert deserialized.any_rule is True
+        assert KriegspielMove(QuestionAnnouncement.ASK_ANY) in deserialized.possible_to_ask
 
     def test_rand_roundtrip_preserves_public_rebuffs_and_pawn_try_squares(self):
         game = BerkeleyGame(ruleset=RULESET_RAND)


### PR DESCRIPTION
## Summary

Adds first-class support for the English / Gambit Club Kriegspiel ruleset in the shared engine.

## What changed

- Added `RULESET_ENGLISH` and `EnglishGame` as a convenience entrypoint over the shared `KriegspielGame` engine.
- Implemented English-specific referee behavior:
  - `Any?` is available.
  - a positive `Any?` answer forces exactly one pawn-capture try.
  - if that pawn-capture try is illegal, the player is released and may make any legal move.
  - illegal attempts are public.
  - captures announce the capture square without pawn-vs-piece identity.
  - promotion is silent.
  - stalemate remains a draw.
- Bumped package version to `1.6.0` and added release notes.
- Added focused English tests plus rules-comparison and serialization coverage.

## Testing

Not run locally per project preference. Remote validation on `rpis02-cf` will be run before merge and posted as a PR comment.
