### PR TITLE
Add CrazyKrieg engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Current scope:
 - Berkeley Kriegspiel
 - Berkeley + Any
 - Cincinnati
+- CrazyKrieg
 - English
 - RAND
 - Wild 16
@@ -48,13 +49,16 @@ loaded = KriegspielGame.load_game("game.json")
 still use `BerkeleyGame` explicitly as a compatibility wrapper, or pick a ruleset
 with `ruleset=...`.
 
-Cincinnati, English, RAND, and Wild 16 also have their own convenience entrypoints:
+Cincinnati, CrazyKrieg, English, RAND, and Wild 16 also have their own convenience entrypoints:
 
 ```python
-from kriegspiel import CincinnatiGame, EnglishGame, RandGame, Wild16Game
+from kriegspiel import CincinnatiGame, CrazyKriegGame, EnglishGame, RandGame, Wild16Game
 
 cincinnati = CincinnatiGame()
 print(cincinnati.current_turn_has_pawn_capture)
+
+crazykrieg = CrazyKriegGame()
+print(crazykrieg.public_reserve_summary)
 
 english = EnglishGame()
 print(english.any_rule)
@@ -71,6 +75,7 @@ print(wild16.current_turn_pawn_tries)
 - `KriegspielGame`: the neutral public entrypoint for the shared hidden-board engine
 - `BerkeleyGame`: backward-compatible Berkeley-named wrapper over `KriegspielGame`
 - `CincinnatiGame`: Cincinnati convenience entrypoint with public `NONSENSE` and binary pawn-capture announcements
+- `CrazyKriegGame`: Crazyhouse Kriegspiel entrypoint with public reserves, hidden drops, and exact reserve-identity capture announcements
 - `EnglishGame`: English convenience entrypoint with public illegal attempts and one-try `ASK_ANY` handling
 - `RandGame`: RAND convenience entrypoint with public rebuffs, pawn-try source-square announcements, typed captures, and promotion notices
 - `Wild16Game`: Wild 16 convenience entrypoint over the shared hidden-board engine

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## Kriegspiel v. 1.7.0
+
+- **CrazyKrieg Support**: added first-class `crazykrieg` ruleset handling plus a dedicated `kriegspiel.crazykrieg.CrazyKriegGame` convenience entrypoint.
+- **Crazyhouse Engine**: CrazyKrieg now uses `python-chess` Crazyhouse boards with public reserves, legal drops, hidden drop squares, and reserve-aware game-end checks.
+- **Referee Announcements**: captures announce the exact unit entering reserve, promoted pawns are announced as pawns when captured, drops announce only the dropped piece type, promotions remain silent, and illegal attempts are public.
+- **Serialization**: schema `8` preserves exact capture identity, drop announcements, Crazyhouse FEN, and Crazyhouse move stacks while still reading schemas `3` through `7`.
+- **Testing**: added focused CrazyKrieg engine, serialization, and rules-comparison coverage for reserves, drops, promoted-pawn capture identity, `Any?`, and public illegal attempts.
+
 ## Kriegspiel v. 1.6.0
 
 - **English Support**: added first-class `english` ruleset handling plus a dedicated `kriegspiel.english.EnglishGame` convenience entrypoint.

--- a/kriegspiel/__init__.py
+++ b/kriegspiel/__init__.py
@@ -4,10 +4,11 @@ __author__ = "Alexander Filatov"
 
 __email__ = "alexander@kriegspiel.org"
 
-__version__ = "1.6.0"
+__version__ = "1.7.0"
 
 from kriegspiel.berkeley import BerkeleyGame
 from kriegspiel.cincinnati import CincinnatiGame
+from kriegspiel.crazykrieg import CrazyKriegGame
 from kriegspiel.english import EnglishGame
 from kriegspiel.game import KriegspielGame
 from kriegspiel.move import CapturedPieceAnnouncement
@@ -21,6 +22,8 @@ from kriegspiel.snapshot import BerkeleyGameSnapshot
 from kriegspiel.snapshot import KriegspielGameSnapshot
 from kriegspiel.snapshot import MaterialSideSummary
 from kriegspiel.snapshot import PublicMaterialSummary
+from kriegspiel.snapshot import PublicReserveSummary
+from kriegspiel.snapshot import ReserveSideSummary
 from kriegspiel.snapshot import ScoresheetSnapshot
 from kriegspiel.wild16 import Wild16Game
 
@@ -29,6 +32,7 @@ __all__ = [
     "BerkeleyGameSnapshot",
     "CincinnatiGame",
     "CapturedPieceAnnouncement",
+    "CrazyKriegGame",
     "EnglishGame",
     "KriegspielAnswer",
     "KriegspielGame",
@@ -37,8 +41,10 @@ __all__ = [
     "MainAnnouncement",
     "MaterialSideSummary",
     "PublicMaterialSummary",
+    "PublicReserveSummary",
     "QuestionAnnouncement",
     "RandGame",
+    "ReserveSideSummary",
     "ScoresheetSnapshot",
     "SpecialCaseAnnouncement",
     "Wild16Game",

--- a/kriegspiel/crazykrieg.py
+++ b/kriegspiel/crazykrieg.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+"""Convenience entrypoint for the CrazyKrieg ruleset."""
+
+from __future__ import annotations
+
+from kriegspiel.game import KriegspielGame
+from kriegspiel.move import KriegspielScoresheet as KSSS
+from kriegspiel.rulesets import RULESET_CRAZYKRIEG
+from kriegspiel.serialization import load_game_from_json
+
+
+class CrazyKriegGame(KriegspielGame):
+    """CrazyKrieg convenience wrapper over the shared hidden-board engine."""
+
+    def __init__(self):
+        super().__init__(ruleset=RULESET_CRAZYKRIEG)
+
+    @classmethod
+    def _from_kriegspiel_game(cls, game):
+        """Rebuild a CrazyKriegGame wrapper from a validated shared-engine instance."""
+        if not isinstance(game, KriegspielGame):
+            raise TypeError("game must be a KriegspielGame")
+        if game.ruleset_id != RULESET_CRAZYKRIEG:
+            raise ValueError("game must use the crazykrieg ruleset")
+
+        instance = cls()
+        instance._board = game._board.copy(stack=True)
+        instance._must_use_pawns = game._must_use_pawns
+        instance._game_over = game._game_over
+        instance._possible_to_ask = list(game.possible_to_ask)
+        instance._possible_to_ask_set = set(game.possible_to_ask)
+        instance._whites_scoresheet = KSSS.from_snapshot(game._whites_scoresheet.snapshot())
+        instance._blacks_scoresheet = KSSS.from_snapshot(game._blacks_scoresheet.snapshot())
+        return instance
+
+    @classmethod
+    def from_snapshot(cls, snapshot):
+        """Build a CrazyKriegGame from a validated snapshot."""
+        return cls._from_kriegspiel_game(KriegspielGame.from_snapshot(snapshot))
+
+    @classmethod
+    def load_game(cls, filename):
+        """Load a CrazyKrieg game from disk."""
+        return cls._from_kriegspiel_game(load_game_from_json(filename))

--- a/kriegspiel/game.py
+++ b/kriegspiel/game.py
@@ -15,6 +15,8 @@ from kriegspiel.rulesets import resolve_ruleset_policy
 from kriegspiel.snapshot import KriegspielGameSnapshot
 from kriegspiel.snapshot import MaterialSideSummary
 from kriegspiel.snapshot import PublicMaterialSummary
+from kriegspiel.snapshot import PublicReserveSummary
+from kriegspiel.snapshot import ReserveSideSummary
 from kriegspiel.snapshot import move_stack_from_scoresheets
 from kriegspiel.serialization import save_game_to_json, load_game_from_json
 
@@ -26,11 +28,12 @@ class KriegspielGame(object):
     """
     Shared hidden-board Kriegspiel referee engine.
 
-    Ruleset-specific behavior such as Berkeley `ASK_ANY`, English one-try
-    `ASK_ANY`, Cincinnati binary pawn-capture announcements, RAND pawn-try
-    source squares, or Wild 16 pawn-try counts is delegated to a policy layer.
-    Variant-named wrappers like `BerkeleyGame`, `EnglishGame`, `CincinnatiGame`,
-    `RandGame`, and `Wild16Game` build on this class.
+    Ruleset-specific behavior such as Berkeley `ASK_ANY`, CrazyKrieg reserves,
+    English one-try `ASK_ANY`, Cincinnati binary pawn-capture announcements,
+    RAND pawn-try source squares, or Wild 16 pawn-try counts is delegated to a
+    policy layer. Variant-named wrappers like `BerkeleyGame`, `CrazyKriegGame`,
+    `EnglishGame`, `CincinnatiGame`, `RandGame`, and `Wild16Game` build on this
+    class.
 
     Communication with this class must be in the form of questions —
     KriegspielMove(s) with QuestionAnnouncement(s).
@@ -47,13 +50,13 @@ class KriegspielGame(object):
             any_rule: Legacy compatibility flag for Berkeley+Any. When omitted,
                      Berkeley+Any remains the default.
             ruleset: Explicit ruleset identifier. Supported values are
-                     `berkeley`, `berkeley_any`, `cincinnati`, `english`,
-                     `rand`, and `wild16`.
+                     `berkeley`, `berkeley_any`, `cincinnati`, `crazykrieg`,
+                     `english`, `rand`, and `wild16`.
         """
         super().__init__()
         self._ruleset = resolve_ruleset_policy(ruleset=ruleset, any_rule=any_rule)
         self._any_rule = self._ruleset.allow_ask_any
-        self._board = chess.Board()
+        self._board = self._ruleset.new_board()
         self._must_use_pawns = False
         self._game_over = False
         self._possible_to_ask = []
@@ -114,7 +117,12 @@ class KriegspielGame(object):
             if self._is_legal_move(move.chess_move):
                 # Move is legal in normal chess
                 # Perform normal move
-                captured_square, captured_piece_announcement, promotion_announced = self._make_move(
+                (
+                    captured_square,
+                    captured_piece_announcement,
+                    dropped_piece_announcement,
+                    promotion_announced,
+                ) = self._make_move(
                     move.chess_move
                 )
                 special_case = self._check_special_cases()
@@ -124,6 +132,8 @@ class KriegspielGame(object):
                 answer_kwargs = {"special_announcement": special_case}
                 if promotion_announced:
                     answer_kwargs["promotion_announced"] = True
+                if dropped_piece_announcement is not None:
+                    answer_kwargs["dropped_piece_announcement"] = dropped_piece_announcement
                 if next_turn_pawn_tries is not None:
                     answer_kwargs["next_turn_pawn_tries"] = next_turn_pawn_tries
                 if next_turn_has_pawn_capture is not None:
@@ -179,7 +189,7 @@ class KriegspielGame(object):
         # Or it is new condition.
         if (
             self._board.is_stalemate()
-            or self._board.is_insufficient_material()
+            or self._is_insufficient_material()
             or self._board.is_checkmate()
             or self._board.halfmove_clock == HALFMOVE_CLOCK_LIMIT
         ):
@@ -264,7 +274,7 @@ class KriegspielGame(object):
                         else SCA.STALEMATE_WHITE_WINS
                     )
                 return SCA.DRAW_STALEMATE
-            if self._board.is_insufficient_material():
+            if self._is_insufficient_material():
                 return SCA.DRAW_INSUFFICIENT
             if self._board.is_checkmate():
                 result = self._board.result()
@@ -314,6 +324,13 @@ class KriegspielGame(object):
         captured_square = self._get_captured_square(move)
         return self._board.piece_at(captured_square)
 
+    def _is_insufficient_material(self):
+        """Treat reserve material as sufficient mating material for drop variants."""
+        if hasattr(self._board, "pockets"):
+            if len(self._board.pockets[chess.WHITE]) or len(self._board.pockets[chess.BLACK]):
+                return False
+        return self._board.is_insufficient_material()
+
     def _make_move(self, move):
         """
         Make the move on the referee's board
@@ -322,13 +339,18 @@ class KriegspielGame(object):
         self._must_use_pawns = False
         captured_square = None
         captured_piece_announcement = None
+        dropped_piece_announcement = self._ruleset.dropped_piece_announcement_for(KSMove(QA.COMMON, move))
         promotion_announced = bool(move.promotion and self._ruleset.announce_promotion)
         if self._board.is_capture(move):
             captured_square = self._get_captured_square(move)
             captured_piece = self._get_captured_piece(move)
-            captured_piece_announcement = self._ruleset.captured_piece_announcement_for(captured_piece)
+            captured_piece_announcement = self._ruleset.captured_piece_announcement_for(
+                captured_piece,
+                board=self._board,
+                captured_square=captured_square,
+            )
         self._board.push(move)
-        return captured_square, captured_piece_announcement, promotion_announced
+        return captured_square, captured_piece_announcement, dropped_piece_announcement, promotion_announced
 
     def _legal_pawn_capture_moves(self):
         """Return legal pawn captures for the active player in the true position."""
@@ -567,6 +589,26 @@ class KriegspielGame(object):
             ),
         )
 
+    @staticmethod
+    def _reserve_summary_from_pocket(pocket):
+        return ReserveSideSummary(
+            pawns=pocket.count(chess.PAWN),
+            knights=pocket.count(chess.KNIGHT),
+            bishops=pocket.count(chess.BISHOP),
+            rooks=pocket.count(chess.ROOK),
+            queens=pocket.count(chess.QUEEN),
+        )
+
+    @property
+    def public_reserve_summary(self):
+        """Return public reserve/pocket material for drop variants."""
+        if not hasattr(self._board, "pockets"):
+            return PublicReserveSummary(white=ReserveSideSummary(), black=ReserveSideSummary())
+        return PublicReserveSummary(
+            white=self._reserve_summary_from_pocket(self._board.pockets[chess.WHITE]),
+            black=self._reserve_summary_from_pocket(self._board.pockets[chess.BLACK]),
+        )
+
     @property
     def must_use_pawns(self):
         """
@@ -633,12 +675,14 @@ class KriegspielGame(object):
         if not isinstance(snapshot, KriegspielGameSnapshot):
             raise TypeError("snapshot must be a KriegspielGameSnapshot")
 
+        ruleset = resolve_ruleset_policy(ruleset=snapshot.ruleset_id)
+
         try:
-            chess.Board(snapshot.board_fen)
+            ruleset.board_from_fen(snapshot.board_fen)
         except ValueError as exc:
             raise ValueError(f"Invalid board FEN: {snapshot.board_fen}") from exc
 
-        board = chess.Board()
+        board = ruleset.new_board()
         try:
             for move_uci in snapshot.move_stack:
                 board.push_uci(move_uci)

--- a/kriegspiel/move.py
+++ b/kriegspiel/move.py
@@ -239,10 +239,14 @@ SINGLE_CHECK = [
 
 @enum.unique
 class CapturedPieceAnnouncement(enum.Enum):
-    """Public capture detail for variants that announce pawn vs piece."""
+    """Public piece detail for capture and drop announcements."""
 
     PAWN = 1
     PIECE = 2
+    KNIGHT = 3
+    BISHOP = 4
+    ROOK = 5
+    QUEEN = 6
 
 
 class KriegspielAnswer(object):
@@ -266,8 +270,10 @@ class KriegspielAnswer(object):
                 capture_at_square (int): Required for CAPTURE_DONE. Square number (0-63)
                                        where the capture occurred.
                 captured_piece_announcement (CapturedPieceAnnouncement): Optional public
-                                    capture detail for variants that distinguish pawn
-                                    captures from other piece captures.
+                                    capture detail for variants that distinguish captured
+                                    material.
+                dropped_piece_announcement (CapturedPieceAnnouncement): Optional public
+                                    drop-piece detail for reserve-drop variants.
                 promotion_announced (bool): Optional RAND-style public statement that
                                     a pawn promoted, without exposing piece type or square.
                 special_announcement: Optional special game state from SpecialCaseAnnouncement
@@ -303,6 +309,7 @@ class KriegspielAnswer(object):
         self._next_turn_has_pawn_capture = None
         self._next_turn_pawn_try_squares = None
         self._promotion_announced = False
+        self._dropped_piece_announcement = None
 
         if main_announcement == MainAnnouncement.CAPTURE_DONE:
             # Validation, that when capture is done, then valid square should
@@ -320,6 +327,16 @@ class KriegspielAnswer(object):
                 self._captured_piece_announcement = captured_piece_announcement
         elif "captured_piece_announcement" in kwargs:
             raise TypeError("captured_piece_announcement is only valid for CAPTURE_DONE")
+
+        if "dropped_piece_announcement" in kwargs:
+            if main_announcement != MainAnnouncement.REGULAR_MOVE:
+                raise TypeError("dropped_piece_announcement is only valid for REGULAR_MOVE")
+            dropped_piece_announcement = kwargs["dropped_piece_announcement"]
+            if not isinstance(dropped_piece_announcement, CapturedPieceAnnouncement):
+                raise TypeError("dropped_piece_announcement must be a CapturedPieceAnnouncement")
+            if dropped_piece_announcement == CapturedPieceAnnouncement.PIECE:
+                raise ValueError("dropped_piece_announcement must be an exact piece type")
+            self._dropped_piece_announcement = dropped_piece_announcement
 
         if "special_announcement" in kwargs:
             sca = kwargs["special_announcement"]
@@ -490,6 +507,16 @@ class KriegspielAnswer(object):
         return self._promotion_announced
 
     @property
+    def dropped_piece_announcement(self):
+        """
+        Get the public piece type for reserve drops.
+
+        Returns:
+            CapturedPieceAnnouncement or None: Exact dropped piece type when available.
+        """
+        return self._dropped_piece_announcement
+
+    @property
     def check_1(self):
         """
         Get the first check type in a double check situation.
@@ -529,6 +556,8 @@ class KriegspielAnswer(object):
             f"special_case={self._special_announcement}",
             f"next_turn_pawn_tries={self._next_turn_pawn_tries}",
         ]
+        if self._dropped_piece_announcement is not None:
+            main_data.append(f"dropped_piece={self._dropped_piece_announcement}")
         if self._next_turn_has_pawn_capture is not None:
             main_data.append(f"next_turn_has_pawn_capture={self._next_turn_has_pawn_capture}")
         if self._next_turn_pawn_try_squares is not None:
@@ -553,6 +582,7 @@ class KriegspielAnswer(object):
             self._next_turn_has_pawn_capture,
             self._next_turn_pawn_try_squares,
             self._promotion_announced,
+            self._dropped_piece_announcement,
             self._check_1,
             self._check_2,
         )
@@ -567,6 +597,7 @@ class KriegspielAnswer(object):
             -1 if self._next_turn_has_pawn_capture is None else int(self._next_turn_has_pawn_capture),
             self._next_turn_pawn_try_squares or (),
             int(self._promotion_announced),
+            self._dropped_piece_announcement.value if self._dropped_piece_announcement is not None else -1,
             self._check_1.value if self._check_1 is not None else -1,
             self._check_2.value if self._check_2 is not None else -1,
         )

--- a/kriegspiel/rulesets.py
+++ b/kriegspiel/rulesets.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import chess
+import chess.variant
 
 from kriegspiel.move import KriegspielAnswer as KSAnswer
 from kriegspiel.move import CapturedPieceAnnouncement as CPA
@@ -16,6 +17,7 @@ from kriegspiel.move import QuestionAnnouncement as QA
 RULESET_BERKELEY = "berkeley"
 RULESET_BERKELEY_ANY = "berkeley_any"
 RULESET_CINCINNATI = "cincinnati"
+RULESET_CRAZYKRIEG = "crazykrieg"
 RULESET_ENGLISH = "english"
 RULESET_RAND = "rand"
 RULESET_WILD16 = "wild16"
@@ -43,6 +45,15 @@ class BerkeleyRulesetPolicy:
     announce_next_turn_pawn_try_squares: bool
     release_ask_any_after_failed_pawn_try: bool
     stalemate_loses: bool
+    board_type: type[chess.Board]
+    exact_capture_announcements: bool
+    announce_drops: bool
+
+    def new_board(self):
+        return self.board_type()
+
+    def board_from_fen(self, fen: str):
+        return self.board_type(fen)
 
     def add_special_questions(self, possibilities: set[KSMove]) -> None:
         if self.allow_ask_any:
@@ -107,12 +118,40 @@ class BerkeleyRulesetPolicy:
             return self.discard_illegal_attempts
         return False
 
-    def captured_piece_announcement_for(self, captured_piece) -> CPA | None:
+    @staticmethod
+    def _exact_piece_announcement_for(piece_type: int) -> CPA:
+        exact_announcements = {
+            chess.PAWN: CPA.PAWN,
+            chess.KNIGHT: CPA.KNIGHT,
+            chess.BISHOP: CPA.BISHOP,
+            chess.ROOK: CPA.ROOK,
+            chess.QUEEN: CPA.QUEEN,
+        }
+        return exact_announcements[piece_type]
+
+    def captured_piece_announcement_for(
+        self,
+        captured_piece,
+        *,
+        board=None,
+        captured_square=None,
+    ) -> CPA | None:
         if not self.typed_capture_announcements or captured_piece is None:
             return None
+        if self.exact_capture_announcements:
+            if board is not None and captured_square is not None:
+                promoted = getattr(board, "promoted", 0)
+                if promoted & chess.BB_SQUARES[captured_square]:
+                    return CPA.PAWN
+            return self._exact_piece_announcement_for(captured_piece.piece_type)
         if captured_piece.piece_type == chess.PAWN:
             return CPA.PAWN
         return CPA.PIECE
+
+    def dropped_piece_announcement_for(self, move: KSMove) -> CPA | None:
+        if not self.announce_drops or move.chess_move is None or move.chess_move.drop is None:
+            return None
+        return self._exact_piece_announcement_for(move.chess_move.drop)
 
     def next_turn_pawn_tries(self, game) -> int | None:
         if not self.announce_next_turn_pawn_tries or game.game_over:
@@ -136,7 +175,7 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
         allow_ask_any = True if any_rule is None else any_rule
         ruleset = RULESET_BERKELEY_ANY if allow_ask_any else RULESET_BERKELEY
     elif any_rule is not None:
-        expected_any_rule = ruleset in {RULESET_BERKELEY_ANY, RULESET_ENGLISH}
+        expected_any_rule = ruleset in {RULESET_BERKELEY_ANY, RULESET_CRAZYKRIEG, RULESET_ENGLISH}
         if expected_any_rule != any_rule:
             raise ValueError(
                 f"ruleset {ruleset!r} conflicts with any_rule={any_rule!r}"
@@ -156,6 +195,9 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             announce_next_turn_pawn_try_squares=False,
             release_ask_any_after_failed_pawn_try=False,
             stalemate_loses=False,
+            board_type=chess.Board,
+            exact_capture_announcements=False,
+            announce_drops=False,
         )
     if ruleset == RULESET_BERKELEY:
         return BerkeleyRulesetPolicy(
@@ -171,6 +213,9 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             announce_next_turn_pawn_try_squares=False,
             release_ask_any_after_failed_pawn_try=False,
             stalemate_loses=False,
+            board_type=chess.Board,
+            exact_capture_announcements=False,
+            announce_drops=False,
         )
     if ruleset == RULESET_CINCINNATI:
         return BerkeleyRulesetPolicy(
@@ -186,6 +231,27 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             announce_next_turn_pawn_try_squares=False,
             release_ask_any_after_failed_pawn_try=False,
             stalemate_loses=False,
+            board_type=chess.Board,
+            exact_capture_announcements=False,
+            announce_drops=False,
+        )
+    if ruleset == RULESET_CRAZYKRIEG:
+        return BerkeleyRulesetPolicy(
+            identifier=ruleset,
+            allow_ask_any=True,
+            invalid_common_attempt_result=MA.NONSENSE,
+            discard_illegal_attempts=True,
+            public_illegal_attempts=True,
+            typed_capture_announcements=True,
+            announce_promotion=False,
+            announce_next_turn_pawn_tries=False,
+            announce_next_turn_has_pawn_capture=False,
+            announce_next_turn_pawn_try_squares=False,
+            release_ask_any_after_failed_pawn_try=True,
+            stalemate_loses=False,
+            board_type=chess.variant.CrazyhouseBoard,
+            exact_capture_announcements=True,
+            announce_drops=True,
         )
     if ruleset == RULESET_ENGLISH:
         return BerkeleyRulesetPolicy(
@@ -201,6 +267,9 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             announce_next_turn_pawn_try_squares=False,
             release_ask_any_after_failed_pawn_try=True,
             stalemate_loses=False,
+            board_type=chess.Board,
+            exact_capture_announcements=False,
+            announce_drops=False,
         )
     if ruleset == RULESET_RAND:
         return BerkeleyRulesetPolicy(
@@ -216,6 +285,9 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             announce_next_turn_pawn_try_squares=True,
             release_ask_any_after_failed_pawn_try=False,
             stalemate_loses=True,
+            board_type=chess.Board,
+            exact_capture_announcements=False,
+            announce_drops=False,
         )
     if ruleset == RULESET_WILD16:
         return BerkeleyRulesetPolicy(
@@ -231,5 +303,8 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             announce_next_turn_pawn_try_squares=False,
             release_ask_any_after_failed_pawn_try=False,
             stalemate_loses=False,
+            board_type=chess.Board,
+            exact_capture_announcements=False,
+            announce_drops=False,
         )
     raise ValueError(f"Unsupported ruleset: {ruleset!r}")

--- a/kriegspiel/serialization.py
+++ b/kriegspiel/serialization.py
@@ -8,8 +8,8 @@ Kriegspiel game components using JSON format with custom encoders/decoders.
 
 JSON Schema Structure:
 {
-  "schema_version": 7,
-  "library_version": "1.6.0",
+  "schema_version": 8,
+  "library_version": "1.7.0",
   "game_type": "BerkeleyGame",
   "game_state": {
     "ruleset_id": "berkeley_any",
@@ -46,6 +46,7 @@ moves_own/moves_opponent: [
         "main_announcement": "REGULAR_MOVE" | "CAPTURE_DONE" | ...,
         "capture_at_square": int | null,
         "captured_piece_announcement": "PAWN" | "PIECE" | null,
+        "dropped_piece_announcement": "PAWN" | "KNIGHT" | "BISHOP" | "ROOK" | "QUEEN" | null,
         "promotion_announced": bool | null,
         "special_announcement": "NONE" | "CHECK_RANK" | ...,
         "next_turn_pawn_tries": int | null,
@@ -80,7 +81,8 @@ LEGACY_SERIALIZATION_SCHEMA_VERSION = 3
 INTERMEDIATE_SERIALIZATION_SCHEMA_VERSION = 4
 PREVIOUS_SERIALIZATION_SCHEMA_VERSION = 5
 CINCINNATI_SERIALIZATION_SCHEMA_VERSION = 6
-SERIALIZATION_SCHEMA_VERSION = 7
+RAND_SERIALIZATION_SCHEMA_VERSION = 7
+SERIALIZATION_SCHEMA_VERSION = 8
 
 
 class SerializationError(Exception):
@@ -227,6 +229,8 @@ def serialize_kriegspiel_answer(answer: KriegspielAnswer) -> Dict[str, Any]:
     }
     if answer.promotion_announced:
         result["promotion_announced"] = True
+    if answer.dropped_piece_announcement is not None:
+        result["dropped_piece_announcement"] = serialize_enum(answer.dropped_piece_announcement)
     if answer.next_turn_has_pawn_capture is not None:
         result["next_turn_has_pawn_capture"] = answer.next_turn_has_pawn_capture
     if answer.next_turn_pawn_try_squares is not None:
@@ -247,6 +251,10 @@ def deserialize_kriegspiel_answer(data: Dict[str, Any]) -> KriegspielAnswer:
         if data.get("captured_piece_announcement") is not None:
             kwargs["captured_piece_announcement"] = deserialize_captured_piece_announcement(
                 data["captured_piece_announcement"]
+            )
+        if data.get("dropped_piece_announcement") is not None:
+            kwargs["dropped_piece_announcement"] = deserialize_captured_piece_announcement(
+                data["dropped_piece_announcement"]
             )
         if data.get("next_turn_pawn_tries") is not None:
             kwargs["next_turn_pawn_tries"] = data["next_turn_pawn_tries"]
@@ -347,7 +355,7 @@ def serialize_berkeley_game(game) -> Dict[str, Any]:
 def deserialize_berkeley_game(data: Dict[str, Any]):
     """Deserialize dictionary to a shared KriegspielGame instance."""
     try:
-        # Check schema compatibility. Live data uses schema 3+; new writes use schema 7.
+        # Check schema compatibility. Live data uses schema 3+; new writes use schema 8.
         schema_version = data.get("schema_version")
         if schema_version is None:
             raise UnsupportedVersionError("Missing schema_version")
@@ -356,6 +364,7 @@ def deserialize_berkeley_game(data: Dict[str, Any]):
             INTERMEDIATE_SERIALIZATION_SCHEMA_VERSION,
             PREVIOUS_SERIALIZATION_SCHEMA_VERSION,
             CINCINNATI_SERIALIZATION_SCHEMA_VERSION,
+            RAND_SERIALIZATION_SCHEMA_VERSION,
             SERIALIZATION_SCHEMA_VERSION,
         }:
             raise UnsupportedVersionError(f"Unsupported schema_version: {schema_version}")

--- a/kriegspiel/snapshot.py
+++ b/kriegspiel/snapshot.py
@@ -44,6 +44,25 @@ class PublicMaterialSummary:
 
 
 @dataclass(frozen=True)
+class ReserveSideSummary:
+    """Public reserve/pocket material for one color."""
+
+    pawns: int = 0
+    knights: int = 0
+    bishops: int = 0
+    rooks: int = 0
+    queens: int = 0
+
+
+@dataclass(frozen=True)
+class PublicReserveSummary:
+    """Public reserve/pocket material for both colors."""
+
+    white: ReserveSideSummary
+    black: ReserveSideSummary
+
+
+@dataclass(frozen=True)
 class KriegspielGameSnapshot:
     """Serializable, public view of a hidden-board Kriegspiel game."""
 

--- a/tests/test_crazykrieg.py
+++ b/tests/test_crazykrieg.py
@@ -150,6 +150,7 @@ def test_crazykrieg_drop_can_give_check_without_revealing_square():
     game = CrazyKriegGame()
     _reset_board(game)
     game._board.set_piece_at(chess.A1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.A2, chess.Piece(chess.ROOK, chess.WHITE))
     game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
     game._board.pockets[chess.WHITE].add(chess.KNIGHT)
     game._generate_possible_to_ask_list()

--- a/tests/test_crazykrieg.py
+++ b/tests/test_crazykrieg.py
@@ -1,0 +1,243 @@
+# -*- coding: utf-8 -*-
+
+"""CrazyKrieg-specific engine and convenience entrypoint tests."""
+
+import os
+import tempfile
+
+import chess.variant
+import pytest
+
+from kriegspiel.berkeley import BerkeleyGame, chess
+from kriegspiel.crazykrieg import CrazyKriegGame
+from kriegspiel.move import CapturedPieceAnnouncement as CPA
+from kriegspiel.move import KriegspielAnswer as KSAnswer
+from kriegspiel.move import KriegspielMove as KSMove
+from kriegspiel.move import MainAnnouncement as MA
+from kriegspiel.move import QuestionAnnouncement as QA
+from kriegspiel.move import SpecialCaseAnnouncement as SCA
+from kriegspiel.rulesets import RULESET_CRAZYKRIEG, resolve_ruleset_policy
+from kriegspiel.snapshot import PublicReserveSummary, ReserveSideSummary
+
+
+def _reset_board(game):
+    game._board.clear()
+    game._board.pockets[chess.WHITE].reset()
+    game._board.pockets[chess.BLACK].reset()
+
+
+def _build_crazy_any_game():
+    game = CrazyKriegGame()
+    _reset_board(game)
+    game._board.set_piece_at(chess.E1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.A1, chess.Piece(chess.ROOK, chess.WHITE))
+    game._board.set_piece_at(chess.E4, chess.Piece(chess.PAWN, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.A5, chess.Piece(chess.KNIGHT, chess.BLACK))
+    game._board.set_piece_at(chess.D5, chess.Piece(chess.BISHOP, chess.BLACK))
+    game._generate_possible_to_ask_list()
+    return game
+
+
+def test_crazykrieg_game_uses_crazyhouse_board_and_policy():
+    game = CrazyKriegGame()
+    policy = resolve_ruleset_policy(ruleset=RULESET_CRAZYKRIEG)
+
+    assert game.ruleset_id == RULESET_CRAZYKRIEG
+    assert isinstance(game._board, chess.variant.CrazyhouseBoard)
+    assert game.any_rule is True
+    assert KSMove(QA.ASK_ANY) in game.possible_to_ask
+    assert game.current_turn_has_pawn_capture is None
+    assert game.current_turn_pawn_tries is None
+    assert game.current_turn_pawn_try_squares is None
+    assert policy.public_illegal_attempts is True
+    assert policy.exact_capture_announcements is True
+    assert policy.announce_drops is True
+
+
+def test_crazykrieg_capture_adds_exact_public_reserve_identity():
+    game = CrazyKriegGame()
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e2e4"))) == KSAnswer(MA.REGULAR_MOVE)
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("d7d5"))) == KSAnswer(MA.REGULAR_MOVE)
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e4d5"))) == KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.D5,
+        captured_piece_announcement=CPA.PAWN,
+    )
+    assert game.public_reserve_summary == PublicReserveSummary(
+        white=ReserveSideSummary(pawns=1),
+        black=ReserveSideSummary(),
+    )
+
+
+def test_crazykrieg_drop_announces_piece_type_but_not_square_to_opponent():
+    game = CrazyKriegGame()
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e2e4")))
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("d7d5")))
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e4d5")))
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("g8f6")))
+
+    drop = KSMove(QA.COMMON, chess.Move.from_uci("P@e3"))
+    answer = KSAnswer(MA.REGULAR_MOVE, dropped_piece_announcement=CPA.PAWN)
+
+    assert drop in game.possible_to_ask
+    assert game.ask_for(drop) == answer
+    assert game.public_reserve_summary.white == ReserveSideSummary()
+    assert game._blacks_scoresheet.moves_opponent[-1][-1] == (QA.COMMON, answer)
+
+
+def test_crazykrieg_drop_on_hidden_occupied_square_is_public_illegal_and_discarded():
+    game = CrazyKriegGame()
+    _reset_board(game)
+    game._board.set_piece_at(chess.A1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.E3, chess.Piece(chess.KNIGHT, chess.BLACK))
+    game._board.pockets[chess.WHITE].add(chess.PAWN)
+    game._generate_possible_to_ask_list()
+    drop = KSMove(QA.COMMON, chess.Move.from_uci("P@e3"))
+
+    assert drop in game.possible_to_ask
+    assert game.ask_for(drop) == KSAnswer(MA.ILLEGAL_MOVE)
+    assert drop not in game.possible_to_ask
+    assert game._blacks_scoresheet.moves_opponent[0][0] == (QA.COMMON, KSAnswer(MA.ILLEGAL_MOVE))
+
+
+def test_crazykrieg_capture_of_promoted_pawn_enters_reserve_as_pawn():
+    game = CrazyKriegGame()
+    _reset_board(game)
+    game._board.set_piece_at(chess.A1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.E8, chess.Piece(chess.QUEEN, chess.WHITE), promoted=True)
+    game._board.set_piece_at(chess.D8, chess.Piece(chess.ROOK, chess.BLACK))
+    game._board.turn = chess.BLACK
+    game._generate_possible_to_ask_list()
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("d8e8"))) == KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.E8,
+        captured_piece_announcement=CPA.PAWN,
+    )
+    assert game.public_reserve_summary.black == ReserveSideSummary(pawns=1)
+
+
+def test_crazykrieg_exact_non_pawn_capture_identity_is_public():
+    game = _build_crazy_any_game()
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move(chess.A1, chess.A5))) == KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.A5,
+        captured_piece_announcement=CPA.KNIGHT,
+    )
+    assert game.public_reserve_summary.white == ReserveSideSummary(knights=1)
+
+
+def test_crazykrieg_any_yes_requires_one_pawn_try_then_releases_after_failed_try():
+    game = _build_crazy_any_game()
+    rook_move = KSMove(QA.COMMON, chess.Move(chess.A1, chess.A5))
+    empty_pawn_try = KSMove(QA.COMMON, chess.Move(chess.E4, chess.F5))
+
+    assert game.ask_for(KSMove(QA.ASK_ANY)) == KSAnswer(MA.HAS_ANY)
+    assert game.must_use_pawns is True
+    assert game.ask_for(rook_move) == KSAnswer(MA.IMPOSSIBLE_TO_ASK)
+    assert game.must_use_pawns is True
+    assert game.ask_for(empty_pawn_try) == KSAnswer(MA.ILLEGAL_MOVE)
+    assert game.must_use_pawns is False
+    assert rook_move in game.possible_to_ask
+
+
+def test_crazykrieg_drop_can_give_check_without_revealing_square():
+    game = CrazyKriegGame()
+    _reset_board(game)
+    game._board.set_piece_at(chess.A1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.pockets[chess.WHITE].add(chess.KNIGHT)
+    game._generate_possible_to_ask_list()
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("N@f7"))) == KSAnswer(
+        MA.REGULAR_MOVE,
+        dropped_piece_announcement=CPA.KNIGHT,
+        special_announcement=SCA.CHECK_KNIGHT,
+    )
+
+
+def test_crazykrieg_reserve_material_prevents_insufficient_material_draw():
+    game = CrazyKriegGame()
+    _reset_board(game)
+    game._board.set_piece_at(chess.A1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.pockets[chess.WHITE].add(chess.PAWN)
+    game._generate_possible_to_ask_list()
+
+    assert game.is_game_over() is False
+
+
+def test_crazykrieg_empty_reserve_keeps_insufficient_material_draw():
+    game = CrazyKriegGame()
+    _reset_board(game)
+    game._board.set_piece_at(chess.A1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._generate_possible_to_ask_list()
+
+    assert game.is_game_over() is True
+
+
+def test_crazykrieg_from_snapshot_returns_variant_instance():
+    game = CrazyKriegGame()
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e2e4")))
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("d7d5")))
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e4d5")))
+
+    restored = CrazyKriegGame.from_snapshot(game.snapshot())
+
+    assert isinstance(restored, CrazyKriegGame)
+    assert restored.ruleset_id == RULESET_CRAZYKRIEG
+    assert restored._board.fen() == game._board.fen()
+    assert restored.public_reserve_summary == game.public_reserve_summary
+
+
+def test_crazykrieg_from_snapshot_rejects_other_ruleset():
+    game = BerkeleyGame(any_rule=False)
+
+    with pytest.raises(ValueError, match="crazykrieg ruleset"):
+        CrazyKriegGame.from_snapshot(game.snapshot())
+
+
+def test_crazykrieg_private_helper_rejects_non_game():
+    with pytest.raises(TypeError, match="KriegspielGame"):
+        CrazyKriegGame._from_kriegspiel_game("not-a-game")
+
+
+def test_crazykrieg_load_game_returns_variant_instance():
+    game = CrazyKriegGame()
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e2e4")))
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("d7d5")))
+    game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e4d5")))
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as handle:
+        filename = handle.name
+
+    try:
+        game.save_game(filename)
+        restored = CrazyKriegGame.load_game(filename)
+    finally:
+        os.unlink(filename)
+
+    assert isinstance(restored, CrazyKriegGame)
+    assert restored.ruleset_id == RULESET_CRAZYKRIEG
+    assert restored._board.fen() == game._board.fen()
+    assert restored.public_reserve_summary == game.public_reserve_summary
+
+
+def test_crazykrieg_load_game_rejects_other_ruleset():
+    game = BerkeleyGame(any_rule=False)
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as handle:
+        filename = handle.name
+
+    try:
+        game.save_game(filename)
+        with pytest.raises(ValueError, match="crazykrieg ruleset"):
+            CrazyKriegGame.load_game(filename)
+    finally:
+        os.unlink(filename)

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -10,14 +10,17 @@ import pytest
 
 from kriegspiel import BerkeleyGame
 from kriegspiel import CincinnatiGame
+from kriegspiel import CrazyKriegGame
 from kriegspiel import EnglishGame
 from kriegspiel import KriegspielGame
 from kriegspiel import KriegspielMove as KSMove
 from kriegspiel import MainAnnouncement as MA
 from kriegspiel import MaterialSideSummary
 from kriegspiel import PublicMaterialSummary
+from kriegspiel import PublicReserveSummary
 from kriegspiel import QuestionAnnouncement as QA
 from kriegspiel import RandGame
+from kriegspiel import ReserveSideSummary
 from kriegspiel import Wild16Game
 from kriegspiel.move import CapturedPieceAnnouncement as CPA
 from kriegspiel.move import KriegspielAnswer as KSAnswer
@@ -162,6 +165,15 @@ def test_public_material_summary_hides_pawn_capture_counts_for_untyped_rulesets(
             ),
             id="rand",
         ),
+        pytest.param(
+            CrazyKriegGame(),
+            KSAnswer(
+                MA.CAPTURE_DONE,
+                capture_at_square=chess.D5,
+                captured_piece_announcement=CPA.PAWN,
+            ),
+            id="crazykrieg",
+        ),
     ],
 )
 def test_public_material_summary_counts_public_pawn_captures_for_typed_rulesets(game, expected_answer):
@@ -212,6 +224,15 @@ def test_public_material_summary_counts_public_pawn_captures_for_typed_rulesets(
                 next_turn_pawn_try_squares=tuple(),
             ),
             id="rand",
+        ),
+        pytest.param(
+            CrazyKriegGame(),
+            KSAnswer(
+                MA.CAPTURE_DONE,
+                capture_at_square=chess.A5,
+                captured_piece_announcement=CPA.KNIGHT,
+            ),
+            id="crazykrieg",
         ),
     ],
 )
@@ -275,12 +296,22 @@ def test_public_material_summary_handles_rand_announced_promotion_without_pawn_c
     )
 
 
+def test_public_reserve_summary_is_zero_for_non_drop_rulesets():
+    assert BerkeleyGame().public_reserve_summary == PublicReserveSummary(
+        white=ReserveSideSummary(),
+        black=ReserveSideSummary(),
+    )
+
+
 def test_package_root_exports_variant_entrypoints():
     assert KriegspielGame.__name__ == "KriegspielGame"
     assert BerkeleyGame.__name__ == "BerkeleyGame"
     assert CincinnatiGame.__name__ == "CincinnatiGame"
+    assert CrazyKriegGame.__name__ == "CrazyKriegGame"
     assert EnglishGame.__name__ == "EnglishGame"
     assert RandGame.__name__ == "RandGame"
     assert Wild16Game.__name__ == "Wild16Game"
     assert MaterialSideSummary.__name__ == "MaterialSideSummary"
     assert PublicMaterialSummary.__name__ == "PublicMaterialSummary"
+    assert PublicReserveSummary.__name__ == "PublicReserveSummary"
+    assert ReserveSideSummary.__name__ == "ReserveSideSummary"

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -217,6 +217,16 @@ def test_capture_answer_can_include_public_capture_kind():
     assert answer.captured_piece_announcement == CPA.PAWN
 
 
+def test_capture_answer_can_include_exact_public_capture_identity():
+    answer = KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.E4,
+        captured_piece_announcement=CPA.QUEEN,
+    )
+
+    assert answer.captured_piece_announcement == CPA.QUEEN
+
+
 def test_capture_answer_rejects_invalid_public_capture_kind():
     with pytest.raises(TypeError, match="captured_piece_announcement must be a CapturedPieceAnnouncement"):
         KSAnswer(
@@ -229,6 +239,23 @@ def test_capture_answer_rejects_invalid_public_capture_kind():
 def test_non_capture_answer_rejects_public_capture_kind():
     with pytest.raises(TypeError, match="captured_piece_announcement is only valid for CAPTURE_DONE"):
         KSAnswer(MA.REGULAR_MOVE, captured_piece_announcement=CPA.PAWN)
+
+
+def test_regular_move_answer_can_include_public_drop_identity():
+    answer = KSAnswer(MA.REGULAR_MOVE, dropped_piece_announcement=CPA.KNIGHT)
+
+    assert answer.dropped_piece_announcement == CPA.KNIGHT
+
+
+def test_drop_identity_rejects_generic_piece_and_invalid_context():
+    with pytest.raises(ValueError, match="must be an exact piece type"):
+        KSAnswer(MA.REGULAR_MOVE, dropped_piece_announcement=CPA.PIECE)
+
+    with pytest.raises(TypeError, match="dropped_piece_announcement must be a CapturedPieceAnnouncement"):
+        KSAnswer(MA.REGULAR_MOVE, dropped_piece_announcement="knight")
+
+    with pytest.raises(TypeError, match="dropped_piece_announcement is only valid for REGULAR_MOVE"):
+        KSAnswer(MA.CAPTURE_DONE, capture_at_square=chess.E4, dropped_piece_announcement=CPA.PAWN)
 
 
 def test_next_turn_pawn_tries_validation():
@@ -449,6 +476,16 @@ def test_ksanswer_str_with_rand_payload():
         "capture_at=None, captured_piece=None, special_case=SpecialCaseAnnouncement.NONE, "
         "next_turn_pawn_tries=None, next_turn_pawn_try_squares=('e4',), "
         "promotion_announced=True>"
+    )
+
+
+def test_ksanswer_str_with_drop_payload():
+    answer = KSAnswer(MA.REGULAR_MOVE, dropped_piece_announcement=CPA.KNIGHT)
+
+    assert str(answer) == (
+        "<KriegspielAnswer: MainAnnouncement.REGULAR_MOVE, "
+        "capture_at=None, captured_piece=None, special_case=SpecialCaseAnnouncement.NONE, "
+        "next_turn_pawn_tries=None, dropped_piece=CapturedPieceAnnouncement.KNIGHT>"
     )
 
 

--- a/tests/test_rules_comparison.py
+++ b/tests/test_rules_comparison.py
@@ -6,6 +6,7 @@ import pytest
 
 from kriegspiel.berkeley import BerkeleyGame, chess
 from kriegspiel.cincinnati import CincinnatiGame
+from kriegspiel.crazykrieg import CrazyKriegGame
 from kriegspiel.english import EnglishGame
 from kriegspiel.move import CapturedPieceAnnouncement as CPA
 from kriegspiel.move import KriegspielAnswer as KSAnswer
@@ -64,6 +65,7 @@ def test_rules_comparison_position_announces_ruleset_specific_pawn_capture_metad
     berkeley_any = _build_rules_comparison_game(BerkeleyGame())
     berkeley = _build_rules_comparison_game(BerkeleyGame(any_rule=False))
     cincinnati = _build_rules_comparison_game(CincinnatiGame())
+    crazykrieg = _build_rules_comparison_game(CrazyKriegGame())
     english = _build_rules_comparison_game(EnglishGame())
     rand = _build_rules_comparison_game(RandGame())
     wild16 = _build_rules_comparison_game(Wild16Game())
@@ -71,6 +73,7 @@ def test_rules_comparison_position_announces_ruleset_specific_pawn_capture_metad
     assert KSMove(QA.ASK_ANY) in berkeley_any.possible_to_ask
     assert KSMove(QA.ASK_ANY) not in berkeley.possible_to_ask
     assert KSMove(QA.ASK_ANY) not in cincinnati.possible_to_ask
+    assert KSMove(QA.ASK_ANY) in crazykrieg.possible_to_ask
     assert KSMove(QA.ASK_ANY) in english.possible_to_ask
     assert KSMove(QA.ASK_ANY) not in rand.possible_to_ask
     assert KSMove(QA.ASK_ANY) not in wild16.possible_to_ask
@@ -81,6 +84,9 @@ def test_rules_comparison_position_announces_ruleset_specific_pawn_capture_metad
     assert berkeley.current_turn_pawn_tries is None
     assert cincinnati.current_turn_has_pawn_capture is True
     assert cincinnati.current_turn_pawn_tries is None
+    assert crazykrieg.current_turn_has_pawn_capture is None
+    assert crazykrieg.current_turn_pawn_tries is None
+    assert crazykrieg.current_turn_pawn_try_squares is None
     assert english.current_turn_has_pawn_capture is None
     assert english.current_turn_pawn_tries is None
     assert english.current_turn_pawn_try_squares is None
@@ -98,6 +104,7 @@ def test_rules_comparison_position_announces_ruleset_specific_pawn_capture_metad
         pytest.param(BerkeleyGame(), None, None, id="berkeley-any"),
         pytest.param(BerkeleyGame(any_rule=False), None, None, id="berkeley"),
         pytest.param(CincinnatiGame(), True, None, id="cincinnati"),
+        pytest.param(CrazyKriegGame(), None, None, id="crazykrieg"),
         pytest.param(EnglishGame(), None, None, id="english"),
         pytest.param(RandGame(), None, None, id="rand"),
         pytest.param(Wild16Game(), None, 1, id="wild16"),
@@ -138,6 +145,15 @@ def test_rules_comparison_promotion_capture_counts_as_one_pawn_capture(
             EnglishGame(),
             KSAnswer(MA.CAPTURE_DONE, capture_at_square=chess.A5),
             id="english",
+        ),
+        pytest.param(
+            CrazyKriegGame(),
+            KSAnswer(
+                MA.CAPTURE_DONE,
+                capture_at_square=chess.A5,
+                captured_piece_announcement=CPA.KNIGHT,
+            ),
+            id="crazykrieg",
         ),
         pytest.param(
             CincinnatiGame(),
@@ -193,6 +209,7 @@ def test_rules_comparison_berkeley_any_has_any_forces_a_pawn_capture():
     [
         pytest.param(BerkeleyGame(), id="berkeley-any"),
         pytest.param(BerkeleyGame(any_rule=False), id="berkeley"),
+        pytest.param(CrazyKriegGame(), id="crazykrieg"),
         pytest.param(EnglishGame(), id="english"),
     ],
 )

--- a/tests/test_rulesets.py
+++ b/tests/test_rulesets.py
@@ -3,6 +3,7 @@
 """Focused policy tests for shared ruleset behavior."""
 
 import chess
+import chess.variant
 import pytest
 
 from kriegspiel.move import CapturedPieceAnnouncement as CPA
@@ -13,6 +14,7 @@ from kriegspiel.move import QuestionAnnouncement as QA
 from kriegspiel.rulesets import RULESET_BERKELEY
 from kriegspiel.rulesets import RULESET_BERKELEY_ANY
 from kriegspiel.rulesets import RULESET_CINCINNATI
+from kriegspiel.rulesets import RULESET_CRAZYKRIEG
 from kriegspiel.rulesets import RULESET_ENGLISH
 from kriegspiel.rulesets import RULESET_RAND
 from kriegspiel.rulesets import RULESET_WILD16
@@ -23,6 +25,7 @@ def test_resolve_ruleset_policy_accepts_matching_any_rule_flags():
     assert resolve_ruleset_policy(ruleset=RULESET_BERKELEY_ANY, any_rule=True).identifier == RULESET_BERKELEY_ANY
     assert resolve_ruleset_policy(ruleset=RULESET_BERKELEY, any_rule=False).identifier == RULESET_BERKELEY
     assert resolve_ruleset_policy(ruleset=RULESET_CINCINNATI, any_rule=False).identifier == RULESET_CINCINNATI
+    assert resolve_ruleset_policy(ruleset=RULESET_CRAZYKRIEG, any_rule=True).identifier == RULESET_CRAZYKRIEG
     assert resolve_ruleset_policy(ruleset=RULESET_ENGLISH, any_rule=True).identifier == RULESET_ENGLISH
     assert resolve_ruleset_policy(ruleset=RULESET_RAND, any_rule=False).identifier == RULESET_RAND
 
@@ -30,6 +33,11 @@ def test_resolve_ruleset_policy_accepts_matching_any_rule_flags():
 def test_resolve_ruleset_policy_rejects_conflicting_english_any_rule_flag():
     with pytest.raises(ValueError, match="conflicts"):
         resolve_ruleset_policy(ruleset=RULESET_ENGLISH, any_rule=False)
+
+
+def test_resolve_ruleset_policy_rejects_conflicting_crazykrieg_any_rule_flag():
+    with pytest.raises(ValueError, match="conflicts"):
+        resolve_ruleset_policy(ruleset=RULESET_CRAZYKRIEG, any_rule=False)
 
 
 def test_ruleset_policy_controls_opponent_visibility():
@@ -56,6 +64,23 @@ def test_ruleset_policy_announces_piece_captures_for_wild16():
     assert policy.captured_piece_announcement_for(None) is None
     assert policy.captured_piece_announcement_for(chess.Piece(chess.PAWN, chess.WHITE)) == CPA.PAWN
     assert policy.captured_piece_announcement_for(chess.Piece(chess.ROOK, chess.WHITE)) == CPA.PIECE
+
+
+def test_ruleset_policy_announces_exact_capture_and_drop_identity_for_crazykrieg():
+    policy = resolve_ruleset_policy(ruleset=RULESET_CRAZYKRIEG)
+    board = chess.variant.CrazyhouseBoard.empty()
+    board.set_piece_at(chess.E8, chess.Piece(chess.QUEEN, chess.WHITE), promoted=True)
+    drop = KSMove(QA.COMMON, chess.Move.from_uci("N@f3"))
+
+    assert isinstance(policy.new_board(), chess.variant.CrazyhouseBoard)
+    assert isinstance(policy.board_from_fen(chess.variant.CrazyhouseBoard().fen()), chess.variant.CrazyhouseBoard)
+    assert policy.captured_piece_announcement_for(chess.Piece(chess.KNIGHT, chess.BLACK)) == CPA.KNIGHT
+    assert policy.captured_piece_announcement_for(
+        chess.Piece(chess.QUEEN, chess.WHITE),
+        board=board,
+        captured_square=chess.E8,
+    ) == CPA.PAWN
+    assert policy.dropped_piece_announcement_for(drop) == CPA.KNIGHT
 
 
 def test_ruleset_policy_announces_binary_pawn_capture_for_cincinnati():

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -5,6 +5,7 @@ import json
 import tempfile
 import os
 import chess
+import chess.variant
 from types import SimpleNamespace
 
 from kriegspiel.move import (
@@ -28,6 +29,7 @@ from kriegspiel.serialization import (
 from kriegspiel.rulesets import RULESET_BERKELEY
 from kriegspiel.rulesets import RULESET_BERKELEY_ANY
 from kriegspiel.rulesets import RULESET_CINCINNATI
+from kriegspiel.rulesets import RULESET_CRAZYKRIEG
 from kriegspiel.rulesets import RULESET_ENGLISH
 from kriegspiel.rulesets import RULESET_RAND
 from kriegspiel.rulesets import RULESET_WILD16
@@ -60,6 +62,7 @@ class TestChessMoveSerializer:
             chess.Move.from_uci("g1f3"),
             chess.Move.from_uci("e7e8q"),  # Promotion
             chess.Move.from_uci("e1g1"),   # Castling
+            chess.Move.from_uci("N@f3"),   # Crazyhouse drop
         ]
         for move in moves:
             serialized = serialize_chess_move(move)
@@ -90,6 +93,9 @@ class TestEnumSerializer:
     def test_deserialize_captured_piece_announcement_invalid(self):
         with pytest.raises(MalformedDataError, match="Invalid CapturedPieceAnnouncement"):
             deserialize_captured_piece_announcement("NOT_A_CAPTURE_KIND")
+
+    def test_deserialize_exact_captured_piece_announcement(self):
+        assert deserialize_captured_piece_announcement("QUEEN") == CapturedPieceAnnouncement.QUEEN
     
     def test_enum_roundtrip(self):
         enums_to_test = [
@@ -104,6 +110,8 @@ class TestEnumSerializer:
             (SpecialCaseAnnouncement.CHECKMATE_WHITE_WINS, deserialize_special_case_announcement),
             (SpecialCaseAnnouncement.STALEMATE_WHITE_WINS, deserialize_special_case_announcement),
             (SpecialCaseAnnouncement.STALEMATE_BLACK_WINS, deserialize_special_case_announcement),
+            (CapturedPieceAnnouncement.KNIGHT, deserialize_captured_piece_announcement),
+            (CapturedPieceAnnouncement.QUEEN, deserialize_captured_piece_announcement),
         ]
         
         for enum_val, deserializer in enums_to_test:
@@ -373,6 +381,40 @@ class TestKriegspielAnswerSerializer:
             promotion_announced=True,
             next_turn_pawn_try_squares=(chess.C2, chess.E4),
         )
+
+    def test_serialize_crazykrieg_answer_fields(self):
+        answer = KriegspielAnswer(
+            MainAnnouncement.REGULAR_MOVE,
+            dropped_piece_announcement=CapturedPieceAnnouncement.KNIGHT,
+        )
+
+        assert serialize_kriegspiel_answer(answer) == {
+            "main_announcement": "REGULAR_MOVE",
+            "capture_at_square": None,
+            "captured_piece_announcement": None,
+            "special_announcement": "NONE",
+            "next_turn_pawn_tries": None,
+            "check_1": None,
+            "check_2": None,
+            "dropped_piece_announcement": "KNIGHT",
+        }
+
+    def test_deserialize_crazykrieg_answer_fields(self):
+        data = {
+            "main_announcement": "REGULAR_MOVE",
+            "capture_at_square": None,
+            "captured_piece_announcement": None,
+            "special_announcement": "NONE",
+            "next_turn_pawn_tries": None,
+            "check_1": None,
+            "check_2": None,
+            "dropped_piece_announcement": "ROOK",
+        }
+
+        assert deserialize_kriegspiel_answer(data) == KriegspielAnswer(
+            MainAnnouncement.REGULAR_MOVE,
+            dropped_piece_announcement=CapturedPieceAnnouncement.ROOK,
+        )
     
     def test_kriegspiel_answer_roundtrip(self):
         answers = [
@@ -391,6 +433,10 @@ class TestKriegspielAnswerSerializer:
             KriegspielAnswer(MainAnnouncement.REGULAR_MOVE, next_turn_has_pawn_capture=True),
             KriegspielAnswer(MainAnnouncement.REGULAR_MOVE, next_turn_pawn_try_squares=(chess.E4,)),
             KriegspielAnswer(MainAnnouncement.REGULAR_MOVE, promotion_announced=True),
+            KriegspielAnswer(
+                MainAnnouncement.REGULAR_MOVE,
+                dropped_piece_announcement=CapturedPieceAnnouncement.BISHOP,
+            ),
         ]
         
         for answer in answers:
@@ -508,6 +554,14 @@ class TestBerkeleyGameSerializer:
         assert result["game_state"]["ruleset_id"] == RULESET_ENGLISH
         assert result["game_state"]["any_rule"] is True
 
+    def test_serialize_crazykrieg_game(self):
+        game = BerkeleyGame(ruleset=RULESET_CRAZYKRIEG)
+        result = serialize_berkeley_game(game)
+
+        assert result["game_state"]["ruleset_id"] == RULESET_CRAZYKRIEG
+        assert result["game_state"]["any_rule"] is True
+        assert result["game_state"]["board_fen"] == chess.variant.CrazyhouseBoard().fen()
+
     def test_serialize_rand_game(self):
         game = BerkeleyGame(ruleset=RULESET_RAND)
         result = serialize_berkeley_game(game)
@@ -623,6 +677,27 @@ class TestBerkeleyGameSerializer:
         assert deserialized.ruleset_id == RULESET_ENGLISH
         assert deserialized.any_rule is True
         assert KriegspielMove(QuestionAnnouncement.ASK_ANY) in deserialized.possible_to_ask
+
+    def test_crazykrieg_roundtrip_preserves_pockets_drops_and_public_metadata(self):
+        game = BerkeleyGame(ruleset=RULESET_CRAZYKRIEG)
+        game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move.from_uci("e2e4")))
+        game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move.from_uci("d7d5")))
+        game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move.from_uci("e4d5")))
+        game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move.from_uci("g8f6")))
+        game.ask_for(KriegspielMove(QuestionAnnouncement.COMMON, chess.Move.from_uci("P@e3")))
+        serialized = serialize_berkeley_game(game)
+        deserialized = deserialize_berkeley_game(serialized)
+
+        assert serialized["schema_version"] == SERIALIZATION_SCHEMA_VERSION
+        assert serialized["game_state"]["move_stack"] == ["e2e4", "d7d5", "e4d5", "g8f6", "P@e3"]
+        assert deserialized.ruleset_id == RULESET_CRAZYKRIEG
+        assert isinstance(deserialized._board, chess.variant.CrazyhouseBoard)
+        assert deserialized._board.fen() == game._board.fen()
+        assert deserialized.public_reserve_summary == game.public_reserve_summary
+        assert deserialized._whites_scoresheet.moves_own[-1][-1][1] == KriegspielAnswer(
+            MainAnnouncement.REGULAR_MOVE,
+            dropped_piece_announcement=CapturedPieceAnnouncement.PAWN,
+        )
 
     def test_rand_roundtrip_preserves_public_rebuffs_and_pawn_try_squares(self):
         game = BerkeleyGame(ruleset=RULESET_RAND)


### PR DESCRIPTION
## Summary

Adds first-class CrazyKrieg / Crazyhouse Kriegspiel support to the shared `ks-game` engine.

## What changed

- Added `RULESET_CRAZYKRIEG` and `CrazyKriegGame`.
- Switched board construction to ruleset policy so CrazyKrieg can use `python-chess` `CrazyhouseBoard` while existing rulesets stay on normal `Board`.
- Added exact reserve-identity capture announcements: pawn, knight, bishop, rook, queen.
- Added public drop-piece announcements for legal Crazyhouse drops while keeping drop squares hidden from opponent scoresheets.
- Added public reserve summaries and reserve-aware insufficient-material handling.
- Preserved promoted-pawn Crazyhouse behavior: promoted pawns enter reserve and announce as pawns when captured.
- Bumped package version to `1.7.0` and serialization schema to `8`.
- Added focused CrazyKrieg, move/answer, ruleset, rules-comparison, and serialization coverage.

## Testing

Not run locally per project preference. Remote validation on `rpis02-cf` will be run before merge and posted as a PR comment.
