### PR TITLE
Refine CrazyKrieg material and English Any coverage

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## Kriegspiel v. 1.7.1
+
+- **CrazyKrieg Material**: public material summaries now count actual board
+  pieces from the Crazyhouse engine state and omit pawn-capture counts, leaving
+  reserve contents as the public source for captured material.
+- **English Any? Coverage**: strengthened tests to prove a failed required pawn
+  try releases the player to make any legal move.
+
 ## Kriegspiel v. 1.7.0
 
 - **CrazyKrieg Support**: added first-class `crazykrieg` ruleset handling plus a dedicated `kriegspiel.crazykrieg.CrazyKriegGame` convenience entrypoint.

--- a/kriegspiel/__init__.py
+++ b/kriegspiel/__init__.py
@@ -4,7 +4,7 @@ __author__ = "Alexander Filatov"
 
 __email__ = "alexander@kriegspiel.org"
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 
 from kriegspiel.berkeley import BerkeleyGame
 from kriegspiel.cincinnati import CincinnatiGame

--- a/kriegspiel/game.py
+++ b/kriegspiel/game.py
@@ -559,6 +559,9 @@ class KriegspielGame(object):
                     pawn_captures += 1
         return captures, pawn_captures
 
+    def _board_piece_count(self, color):
+        return sum(1 for piece in self._board.piece_map().values() if piece.color == color)
+
     @property
     def public_material_summary(self):
         """
@@ -570,6 +573,18 @@ class KriegspielGame(object):
         completed capture answers instead of true-board pawn counts so promotion
         remains tied to what the referee publicly announced.
         """
+        if self._ruleset.material_summary_from_board:
+            return PublicMaterialSummary(
+                white=MaterialSideSummary(
+                    pieces_remaining=self._board_piece_count(chess.WHITE),
+                    pawns_captured=None,
+                ),
+                black=MaterialSideSummary(
+                    pieces_remaining=self._board_piece_count(chess.BLACK),
+                    pawns_captured=None,
+                ),
+            )
+
         white_captures, white_pawn_captures = self._capture_counts_from_completed_moves(
             self._whites_scoresheet.moves_own
         )

--- a/kriegspiel/rulesets.py
+++ b/kriegspiel/rulesets.py
@@ -48,6 +48,7 @@ class BerkeleyRulesetPolicy:
     board_type: type[chess.Board]
     exact_capture_announcements: bool
     announce_drops: bool
+    material_summary_from_board: bool = False
 
     def new_board(self):
         return self.board_type()
@@ -252,6 +253,7 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             board_type=chess.variant.CrazyhouseBoard,
             exact_capture_announcements=True,
             announce_drops=True,
+            material_summary_from_board=True,
         )
     if ruleset == RULESET_ENGLISH:
         return BerkeleyRulesetPolicy(

--- a/tests/test_crazykrieg.py
+++ b/tests/test_crazykrieg.py
@@ -17,7 +17,7 @@ from kriegspiel.move import MainAnnouncement as MA
 from kriegspiel.move import QuestionAnnouncement as QA
 from kriegspiel.move import SpecialCaseAnnouncement as SCA
 from kriegspiel.rulesets import RULESET_CRAZYKRIEG, resolve_ruleset_policy
-from kriegspiel.snapshot import PublicReserveSummary, ReserveSideSummary
+from kriegspiel.snapshot import MaterialSideSummary, PublicMaterialSummary, PublicReserveSummary, ReserveSideSummary
 
 
 def _reset_board(game):
@@ -130,6 +130,37 @@ def test_crazykrieg_exact_non_pawn_capture_identity_is_public():
         captured_piece_announcement=CPA.KNIGHT,
     )
     assert game.public_reserve_summary.white == ReserveSideSummary(knights=1)
+
+
+def test_crazykrieg_material_summary_counts_board_pieces_without_pawn_counts():
+    game = CrazyKriegGame()
+
+    assert game.public_material_summary == PublicMaterialSummary(
+        white=MaterialSideSummary(pieces_remaining=16, pawns_captured=None),
+        black=MaterialSideSummary(pieces_remaining=16, pawns_captured=None),
+    )
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e2e4"))) == KSAnswer(MA.REGULAR_MOVE)
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("d7d5"))) == KSAnswer(MA.REGULAR_MOVE)
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e4d5"))) == KSAnswer(
+        MA.CAPTURE_DONE,
+        capture_at_square=chess.D5,
+        captured_piece_announcement=CPA.PAWN,
+    )
+    assert game.public_material_summary == PublicMaterialSummary(
+        white=MaterialSideSummary(pieces_remaining=16, pawns_captured=None),
+        black=MaterialSideSummary(pieces_remaining=15, pawns_captured=None),
+    )
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("g8f6"))) == KSAnswer(MA.REGULAR_MOVE)
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("P@e3"))) == KSAnswer(
+        MA.REGULAR_MOVE,
+        dropped_piece_announcement=CPA.PAWN,
+    )
+    assert game.public_material_summary == PublicMaterialSummary(
+        white=MaterialSideSummary(pieces_remaining=17, pawns_captured=None),
+        black=MaterialSideSummary(pieces_remaining=15, pawns_captured=None),
+    )
 
 
 def test_crazykrieg_any_yes_requires_one_pawn_try_then_releases_after_failed_try():

--- a/tests/test_english.py
+++ b/tests/test_english.py
@@ -81,6 +81,7 @@ def test_english_failed_pawn_try_releases_any_obligation():
     assert game.must_use_pawns is False
     assert rook_move in game.possible_to_ask
     assert empty_pawn_try not in game.possible_to_ask
+    assert game.ask_for(rook_move) == KSAnswer(MA.CAPTURE_DONE, capture_at_square=chess.A5)
 
 
 def test_english_legal_pawn_capture_after_any_completes_move():

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -165,15 +165,6 @@ def test_public_material_summary_hides_pawn_capture_counts_for_untyped_rulesets(
             ),
             id="rand",
         ),
-        pytest.param(
-            CrazyKriegGame(),
-            KSAnswer(
-                MA.CAPTURE_DONE,
-                capture_at_square=chess.D5,
-                captured_piece_announcement=CPA.PAWN,
-            ),
-            id="crazykrieg",
-        ),
     ],
 )
 def test_public_material_summary_counts_public_pawn_captures_for_typed_rulesets(game, expected_answer):
@@ -224,15 +215,6 @@ def test_public_material_summary_counts_public_pawn_captures_for_typed_rulesets(
                 next_turn_pawn_try_squares=tuple(),
             ),
             id="rand",
-        ),
-        pytest.param(
-            CrazyKriegGame(),
-            KSAnswer(
-                MA.CAPTURE_DONE,
-                capture_at_square=chess.A5,
-                captured_piece_announcement=CPA.KNIGHT,
-            ),
-            id="crazykrieg",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

- Count CrazyKrieg public material from the actual Crazyhouse board state, so reserve drops can take remaining board material above 16 when appropriate.
- Omit CrazyKrieg pawn-capture counts from `public_material_summary`; reserves remain the public captured-material source.
- Strengthen English `Any?` coverage to prove a failed required pawn try releases the player to make any legal move.
- Bump package version to `1.7.1` and update release notes.

## Local validation

- `.venv/bin/pytest -q` -> 382 passed, 100% line coverage, 100% branch coverage
- `.venv/bin/python -m compileall -q kriegspiel tests`
- `git diff --check`