### PR TITLE
Test double check components across rulesets

### DIFF
--- a/tests/test_rules_comparison.py
+++ b/tests/test_rules_comparison.py
@@ -13,6 +13,7 @@ from kriegspiel.move import KriegspielAnswer as KSAnswer
 from kriegspiel.move import KriegspielMove as KSMove
 from kriegspiel.move import MainAnnouncement as MA
 from kriegspiel.move import QuestionAnnouncement as QA
+from kriegspiel.move import SpecialCaseAnnouncement as SCA
 from kriegspiel.rand import RandGame
 from kriegspiel.wild16 import Wild16Game
 
@@ -58,6 +59,16 @@ def _promotion_capture_moves():
         KSMove(QA.COMMON, chess.Move(chess.D2, chess.C1, promotion=promotion))
         for promotion in (chess.QUEEN, chess.ROOK, chess.BISHOP, chess.KNIGHT)
     }
+
+
+def _build_double_check_game(game):
+    game._board.clear()
+    game._board.set_piece_at(chess.C2, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.E2, chess.Piece(chess.QUEEN, chess.BLACK))
+    game._board.set_piece_at(chess.D2, chess.Piece(chess.KNIGHT, chess.BLACK))
+    game._generate_possible_to_ask_list()
+    return game
 
 
 @pytest.mark.rules
@@ -148,6 +159,31 @@ def test_rules_comparison_only_rand_announces_promotion(game, expected_promotion
 
     assert answer.main_announcement == MA.CAPTURE_DONE
     assert answer.promotion_announced is expected_promotion_announced
+
+
+@pytest.mark.rules
+@pytest.mark.parametrize(
+    "game",
+    [
+        pytest.param(BerkeleyGame(), id="berkeley-any"),
+        pytest.param(BerkeleyGame(any_rule=False), id="berkeley"),
+        pytest.param(CincinnatiGame(), id="cincinnati"),
+        pytest.param(CrazyKriegGame(), id="crazykrieg"),
+        pytest.param(EnglishGame(), id="english"),
+        pytest.param(RandGame(), id="rand"),
+        pytest.param(Wild16Game(), id="wild16"),
+    ],
+)
+def test_rules_comparison_double_check_preserves_both_component_announcements(game):
+    game = _build_double_check_game(game)
+
+    game.ask_for(KSMove(QA.COMMON, chess.Move(chess.C2, chess.B2)))
+    answer = game.ask_for(KSMove(QA.COMMON, chess.Move(chess.D2, chess.C4)))
+
+    assert answer.main_announcement == MA.REGULAR_MOVE
+    assert answer.special_announcement == SCA.CHECK_DOUBLE
+    assert answer.check_1 == SCA.CHECK_RANK
+    assert answer.check_2 == SCA.CHECK_KNIGHT
 
 
 @pytest.mark.rules


### PR DESCRIPTION
Summary
- Add rules-comparison coverage proving double-check answers preserve both component check announcements across Berkeley, Berkeley+Any, Cincinnati, CrazyKrieg, English, RAND, and Wild 16.

Rationale
- The engine already carries component check details on double-check answers; this regression test protects that behavior across every ruleset wrapper.

Tests
- PYTHONPATH=/home/codex/dev/kriegspiel/_worktrees/ks-game-double-check-components /home/codex/dev/kriegspiel/ks-game/.venv/bin/python -m pytest tests/test_rules_comparison.py -q --no-cov (37 passed)
- PYTHONPATH=/home/codex/dev/kriegspiel/_worktrees/ks-game-double-check-components /home/codex/dev/kriegspiel/ks-game/.venv/bin/python -m pytest -m rules -q --no-cov (42 passed, 354 deselected)

Deployment notes
- Test-only engine coverage change; no package version bump or runtime deployment required.

Verified commit: 1481122d2fc758b1a2b3673c25f562f05803c745