### PR TITLE
Announce English en passant captures

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## Kriegspiel v. 1.7.2
+
+- **English En Passant**: English games now announce en passant captures
+  explicitly and use the capturing pawn's landing square for that announcement.
+- **Serialization**: schema `9` preserves en passant announcement metadata
+  while still reading schemas `3` through `8`.
+- **Testing**: added focused English and cross-ruleset coverage for en passant
+  announcement behavior.
+
 ## Kriegspiel v. 1.7.1
 
 - **CrazyKrieg Material**: public material summaries now count actual board

--- a/kriegspiel/__init__.py
+++ b/kriegspiel/__init__.py
@@ -4,7 +4,7 @@ __author__ = "Alexander Filatov"
 
 __email__ = "alexander@kriegspiel.org"
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 
 from kriegspiel.berkeley import BerkeleyGame
 from kriegspiel.cincinnati import CincinnatiGame

--- a/kriegspiel/game.py
+++ b/kriegspiel/game.py
@@ -122,6 +122,7 @@ class KriegspielGame(object):
                     captured_piece_announcement,
                     dropped_piece_announcement,
                     promotion_announced,
+                    en_passant_announced,
                 ) = self._make_move(
                     move.chess_move
                 )
@@ -132,6 +133,8 @@ class KriegspielGame(object):
                 answer_kwargs = {"special_announcement": special_case}
                 if promotion_announced:
                     answer_kwargs["promotion_announced"] = True
+                if en_passant_announced:
+                    answer_kwargs["en_passant_announced"] = True
                 if dropped_piece_announcement is not None:
                     answer_kwargs["dropped_piece_announcement"] = dropped_piece_announcement
                 if next_turn_pawn_tries is not None:
@@ -305,23 +308,27 @@ class KriegspielGame(object):
                 raise RuntimeError
         return SCA.NONE
 
-    def _get_captured_square(self, move):
+    def _get_captured_piece_square(self, move):
         """
-        A square with capture will be announced.
+        Return the true board square of the captured piece.
         """
         if not self._board.is_en_passant(move):
             return move.to_square
-        else:
-            if self._board.turn == chess.WHITE:
-                return move.to_square - 8
-            else:
-                return move.to_square + 8
+        if self._board.turn == chess.WHITE:
+            return move.to_square - 8
+        return move.to_square + 8
+
+    def _get_captured_square(self, move):
+        """
+        Return the public square announced for the capture.
+        """
+        return self._ruleset.capture_square_for(self._board, move)
 
     def _get_captured_piece(self, move):
         """Return the piece removed by a capture before the move is pushed."""
         if not self._board.is_capture(move):
             return None
-        captured_square = self._get_captured_square(move)
+        captured_square = self._get_captured_piece_square(move)
         return self._board.piece_at(captured_square)
 
     def _is_insufficient_material(self):
@@ -339,18 +346,26 @@ class KriegspielGame(object):
         self._must_use_pawns = False
         captured_square = None
         captured_piece_announcement = None
+        en_passant_announced = False
         dropped_piece_announcement = self._ruleset.dropped_piece_announcement_for(KSMove(QA.COMMON, move))
         promotion_announced = bool(move.promotion and self._ruleset.announce_promotion)
         if self._board.is_capture(move):
             captured_square = self._get_captured_square(move)
             captured_piece = self._get_captured_piece(move)
+            en_passant_announced = self._ruleset.en_passant_announced_for(self._board, move)
             captured_piece_announcement = self._ruleset.captured_piece_announcement_for(
                 captured_piece,
                 board=self._board,
                 captured_square=captured_square,
             )
         self._board.push(move)
-        return captured_square, captured_piece_announcement, dropped_piece_announcement, promotion_announced
+        return (
+            captured_square,
+            captured_piece_announcement,
+            dropped_piece_announcement,
+            promotion_announced,
+            en_passant_announced,
+        )
 
     def _legal_pawn_capture_moves(self):
         """Return legal pawn captures for the active player in the true position."""

--- a/kriegspiel/move.py
+++ b/kriegspiel/move.py
@@ -274,6 +274,8 @@ class KriegspielAnswer(object):
                                     material.
                 dropped_piece_announcement (CapturedPieceAnnouncement): Optional public
                                     drop-piece detail for reserve-drop variants.
+                en_passant_announced (bool): Optional English-style public statement
+                                    that a capture was en passant.
                 promotion_announced (bool): Optional RAND-style public statement that
                                     a pawn promoted, without exposing piece type or square.
                 special_announcement: Optional special game state from SpecialCaseAnnouncement
@@ -310,6 +312,7 @@ class KriegspielAnswer(object):
         self._next_turn_pawn_try_squares = None
         self._promotion_announced = False
         self._dropped_piece_announcement = None
+        self._en_passant_announced = False
 
         if main_announcement == MainAnnouncement.CAPTURE_DONE:
             # Validation, that when capture is done, then valid square should
@@ -327,6 +330,14 @@ class KriegspielAnswer(object):
                 self._captured_piece_announcement = captured_piece_announcement
         elif "captured_piece_announcement" in kwargs:
             raise TypeError("captured_piece_announcement is only valid for CAPTURE_DONE")
+
+        if "en_passant_announced" in kwargs:
+            en_passant_announced = kwargs["en_passant_announced"]
+            if not isinstance(en_passant_announced, bool):
+                raise TypeError("en_passant_announced must be a boolean")
+            if en_passant_announced and main_announcement != MainAnnouncement.CAPTURE_DONE:
+                raise TypeError("en_passant_announced is only valid for CAPTURE_DONE")
+            self._en_passant_announced = en_passant_announced
 
         if "dropped_piece_announcement" in kwargs:
             if main_announcement != MainAnnouncement.REGULAR_MOVE:
@@ -507,6 +518,16 @@ class KriegspielAnswer(object):
         return self._promotion_announced
 
     @property
+    def en_passant_announced(self):
+        """
+        Get whether the answer publicly announces an en passant capture.
+
+        Returns:
+            bool: True when the ruleset announces the capture as en passant.
+        """
+        return self._en_passant_announced
+
+    @property
     def dropped_piece_announcement(self):
         """
         Get the public piece type for reserve drops.
@@ -565,6 +586,8 @@ class KriegspielAnswer(object):
             main_data.append(f"next_turn_pawn_try_squares={square_names}")
         if self._promotion_announced:
             main_data.append("promotion_announced=True")
+        if self._en_passant_announced:
+            main_data.append("en_passant_announced=True")
 
         if self._check_1 is not None or self._check_2 is not None:
             extra_data = f"check_1={self._check_1}, check_2={self._check_2}"
@@ -582,6 +605,7 @@ class KriegspielAnswer(object):
             self._next_turn_has_pawn_capture,
             self._next_turn_pawn_try_squares,
             self._promotion_announced,
+            self._en_passant_announced,
             self._dropped_piece_announcement,
             self._check_1,
             self._check_2,
@@ -597,6 +621,7 @@ class KriegspielAnswer(object):
             -1 if self._next_turn_has_pawn_capture is None else int(self._next_turn_has_pawn_capture),
             self._next_turn_pawn_try_squares or (),
             int(self._promotion_announced),
+            int(self._en_passant_announced),
             self._dropped_piece_announcement.value if self._dropped_piece_announcement is not None else -1,
             self._check_1.value if self._check_1 is not None else -1,
             self._check_2.value if self._check_2 is not None else -1,

--- a/kriegspiel/rulesets.py
+++ b/kriegspiel/rulesets.py
@@ -48,6 +48,7 @@ class BerkeleyRulesetPolicy:
     board_type: type[chess.Board]
     exact_capture_announcements: bool
     announce_drops: bool
+    announce_en_passant: bool
     material_summary_from_board: bool = False
 
     def new_board(self):
@@ -149,6 +150,18 @@ class BerkeleyRulesetPolicy:
             return CPA.PAWN
         return CPA.PIECE
 
+    def capture_square_for(self, board, move) -> int:
+        if self.announce_en_passant and board.is_en_passant(move):
+            return move.to_square
+        if not board.is_en_passant(move):
+            return move.to_square
+        if board.turn == chess.WHITE:
+            return move.to_square - 8
+        return move.to_square + 8
+
+    def en_passant_announced_for(self, board, move) -> bool:
+        return self.announce_en_passant and board.is_en_passant(move)
+
     def dropped_piece_announcement_for(self, move: KSMove) -> CPA | None:
         if not self.announce_drops or move.chess_move is None or move.chess_move.drop is None:
             return None
@@ -199,6 +212,7 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             board_type=chess.Board,
             exact_capture_announcements=False,
             announce_drops=False,
+            announce_en_passant=False,
         )
     if ruleset == RULESET_BERKELEY:
         return BerkeleyRulesetPolicy(
@@ -217,6 +231,7 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             board_type=chess.Board,
             exact_capture_announcements=False,
             announce_drops=False,
+            announce_en_passant=False,
         )
     if ruleset == RULESET_CINCINNATI:
         return BerkeleyRulesetPolicy(
@@ -235,6 +250,7 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             board_type=chess.Board,
             exact_capture_announcements=False,
             announce_drops=False,
+            announce_en_passant=False,
         )
     if ruleset == RULESET_CRAZYKRIEG:
         return BerkeleyRulesetPolicy(
@@ -253,6 +269,7 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             board_type=chess.variant.CrazyhouseBoard,
             exact_capture_announcements=True,
             announce_drops=True,
+            announce_en_passant=False,
             material_summary_from_board=True,
         )
     if ruleset == RULESET_ENGLISH:
@@ -272,6 +289,7 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             board_type=chess.Board,
             exact_capture_announcements=False,
             announce_drops=False,
+            announce_en_passant=True,
         )
     if ruleset == RULESET_RAND:
         return BerkeleyRulesetPolicy(
@@ -290,6 +308,7 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             board_type=chess.Board,
             exact_capture_announcements=False,
             announce_drops=False,
+            announce_en_passant=False,
         )
     if ruleset == RULESET_WILD16:
         return BerkeleyRulesetPolicy(
@@ -308,5 +327,6 @@ def resolve_ruleset_policy(*, ruleset: str | None = None, any_rule: bool | None 
             board_type=chess.Board,
             exact_capture_announcements=False,
             announce_drops=False,
+            announce_en_passant=False,
         )
     raise ValueError(f"Unsupported ruleset: {ruleset!r}")

--- a/kriegspiel/serialization.py
+++ b/kriegspiel/serialization.py
@@ -8,8 +8,8 @@ Kriegspiel game components using JSON format with custom encoders/decoders.
 
 JSON Schema Structure:
 {
-  "schema_version": 8,
-  "library_version": "1.7.0",
+  "schema_version": 9,
+  "library_version": "1.7.2",
   "game_type": "BerkeleyGame",
   "game_state": {
     "ruleset_id": "berkeley_any",
@@ -47,6 +47,7 @@ moves_own/moves_opponent: [
         "capture_at_square": int | null,
         "captured_piece_announcement": "PAWN" | "PIECE" | null,
         "dropped_piece_announcement": "PAWN" | "KNIGHT" | "BISHOP" | "ROOK" | "QUEEN" | null,
+        "en_passant_announced": bool | null,
         "promotion_announced": bool | null,
         "special_announcement": "NONE" | "CHECK_RANK" | ...,
         "next_turn_pawn_tries": int | null,
@@ -82,7 +83,8 @@ INTERMEDIATE_SERIALIZATION_SCHEMA_VERSION = 4
 PREVIOUS_SERIALIZATION_SCHEMA_VERSION = 5
 CINCINNATI_SERIALIZATION_SCHEMA_VERSION = 6
 RAND_SERIALIZATION_SCHEMA_VERSION = 7
-SERIALIZATION_SCHEMA_VERSION = 8
+CRAZYKRIEG_SERIALIZATION_SCHEMA_VERSION = 8
+SERIALIZATION_SCHEMA_VERSION = 9
 
 
 class SerializationError(Exception):
@@ -229,6 +231,8 @@ def serialize_kriegspiel_answer(answer: KriegspielAnswer) -> Dict[str, Any]:
     }
     if answer.promotion_announced:
         result["promotion_announced"] = True
+    if answer.en_passant_announced:
+        result["en_passant_announced"] = True
     if answer.dropped_piece_announcement is not None:
         result["dropped_piece_announcement"] = serialize_enum(answer.dropped_piece_announcement)
     if answer.next_turn_has_pawn_capture is not None:
@@ -264,6 +268,8 @@ def deserialize_kriegspiel_answer(data: Dict[str, Any]) -> KriegspielAnswer:
             kwargs["next_turn_pawn_try_squares"] = data["next_turn_pawn_try_squares"]
         if data.get("promotion_announced") is not None:
             kwargs["promotion_announced"] = data["promotion_announced"]
+        if data.get("en_passant_announced") is not None:
+            kwargs["en_passant_announced"] = data["en_passant_announced"]
         
         special_announcement = deserialize_special_case_announcement(data["special_announcement"])
         
@@ -365,6 +371,7 @@ def deserialize_berkeley_game(data: Dict[str, Any]):
             PREVIOUS_SERIALIZATION_SCHEMA_VERSION,
             CINCINNATI_SERIALIZATION_SCHEMA_VERSION,
             RAND_SERIALIZATION_SCHEMA_VERSION,
+            CRAZYKRIEG_SERIALIZATION_SCHEMA_VERSION,
             SERIALIZATION_SCHEMA_VERSION,
         }:
             raise UnsupportedVersionError(f"Unsupported schema_version: {schema_version}")

--- a/tests/test_english.py
+++ b/tests/test_english.py
@@ -101,6 +101,25 @@ def test_english_capture_announces_square_but_not_captured_kind():
 
     assert result == KSAnswer(MA.CAPTURE_DONE, capture_at_square=chess.A5)
     assert result.captured_piece_announcement is None
+    assert result.en_passant_announced is False
+
+
+def test_english_en_passant_is_announced_on_landing_square():
+    game = EnglishGame()
+    game._board.clear()
+    game._board.turn = chess.BLACK
+    game._board.set_piece_at(chess.A1, chess.Piece(chess.KING, chess.WHITE))
+    game._board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK))
+    game._board.set_piece_at(chess.E4, chess.Piece(chess.PAWN, chess.BLACK))
+    game._board.set_piece_at(chess.D4, chess.Piece(chess.PAWN, chess.WHITE))
+    game._board.ep_square = chess.D3
+    game._generate_possible_to_ask_list()
+
+    result = game.ask_for(KSMove(QA.COMMON, chess.Move(chess.E4, chess.D3)))
+
+    assert result == KSAnswer(MA.CAPTURE_DONE, capture_at_square=chess.D3, en_passant_announced=True)
+    assert game._board.piece_at(chess.D4) is None
+    assert game._board.piece_at(chess.D3) == chess.Piece(chess.PAWN, chess.BLACK)
 
 
 def test_english_public_illegal_attempt_is_visible_to_opponent():

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -241,6 +241,20 @@ def test_non_capture_answer_rejects_public_capture_kind():
         KSAnswer(MA.REGULAR_MOVE, captured_piece_announcement=CPA.PAWN)
 
 
+def test_capture_answer_can_announce_en_passant():
+    answer = KSAnswer(MA.CAPTURE_DONE, capture_at_square=chess.F6, en_passant_announced=True)
+
+    assert answer.en_passant_announced is True
+
+
+def test_en_passant_announcement_validation():
+    with pytest.raises(TypeError, match="en_passant_announced must be a boolean"):
+        KSAnswer(MA.CAPTURE_DONE, capture_at_square=chess.F6, en_passant_announced="yes")
+
+    with pytest.raises(TypeError, match="en_passant_announced is only valid for CAPTURE_DONE"):
+        KSAnswer(MA.REGULAR_MOVE, en_passant_announced=True)
+
+
 def test_regular_move_answer_can_include_public_drop_identity():
     answer = KSAnswer(MA.REGULAR_MOVE, dropped_piece_announcement=CPA.KNIGHT)
 

--- a/tests/test_rules_comparison.py
+++ b/tests/test_rules_comparison.py
@@ -318,9 +318,11 @@ def test_rules_comparison_en_passant_capture_can_announce_diagonal_check(game, c
         if game.ruleset_id in {"cincinnati", "crazykrieg", "rand", "wild16"}
         else None
     )
+    expected_capture_square = case["ep_square"] if game.ruleset_id == "english" else case["captured_pawn"]
     assert answer.main_announcement == MA.CAPTURE_DONE
-    assert answer.capture_at_square == case["captured_pawn"]
+    assert answer.capture_at_square == expected_capture_square
     assert answer.captured_piece_announcement == expected_piece
+    assert answer.en_passant_announced is (game.ruleset_id == "english")
     assert answer.special_announcement == case["expected_check"]
     assert game._board.piece_at(case["captured_pawn"]) is None
     assert game._board.piece_at(case["ep_square"]) == chess.Piece(chess.PAWN, chess.BLACK)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -310,6 +310,33 @@ class TestKriegspielAnswerSerializer:
             next_turn_pawn_tries=3,
         )
 
+    def test_serialize_english_en_passant_answer_field(self):
+        answer = KriegspielAnswer(
+            MainAnnouncement.CAPTURE_DONE,
+            capture_at_square=45,
+            en_passant_announced=True,
+        )
+
+        result = serialize_kriegspiel_answer(answer)
+
+        assert result["en_passant_announced"] is True
+
+    def test_deserialize_english_en_passant_answer_field(self):
+        data = {
+            "main_announcement": "CAPTURE_DONE",
+            "capture_at_square": 45,
+            "en_passant_announced": True,
+            "special_announcement": "NONE",
+            "check_1": None,
+            "check_2": None,
+        }
+
+        assert deserialize_kriegspiel_answer(data) == KriegspielAnswer(
+            MainAnnouncement.CAPTURE_DONE,
+            capture_at_square=45,
+            en_passant_announced=True,
+        )
+
     def test_serialize_cincinnati_answer_fields(self):
         answer = KriegspielAnswer(
             MainAnnouncement.REGULAR_MOVE,


### PR DESCRIPTION
Summary
- Add `en_passant_announced` referee-answer metadata for English en-passant captures.
- Make English announce en passant on the capturing pawn's landing square while other rulesets keep ordinary en-passant capture-square behavior.
- Bump `kriegspiel` to `1.7.2` and serialization schema to `9`.

Rationale
English/Eastern rules sources describe en-passant captures as explicitly announced, without turning ordinary English captures into typed pawn/piece captures.

Tests
- `/home/codex/dev/kriegspiel/ks-game/.venv/bin/python -m pytest`

Deployment notes
- Backend should update its `ks-game` dependency to commit `319c11eb64f2d93565d790349ca25d6feff9299e` before runtime deployment.