### PR TITLE
Prevent repeated English Any questions after failed pawn try

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## Kriegspiel v. 1.7.3
+
+- **English Any?**: after a positive `Any?` answer, one failed required pawn
+  try still releases the player to make any legal move, but no longer allows
+  asking `Any?` again in the same ply.
+- **CrazyKrieg Any?**: applied the same one-question-per-ply behavior after a
+  failed required pawn try.
+- **Testing**: added focused English and CrazyKrieg regression coverage for
+  repeated `Any?` attempts after the release.
+
 ## Kriegspiel v. 1.7.2
 
 - **English En Passant**: English games now announce en passant captures

--- a/kriegspiel/__init__.py
+++ b/kriegspiel/__init__.py
@@ -4,7 +4,7 @@ __author__ = "Alexander Filatov"
 
 __email__ = "alexander@kriegspiel.org"
 
-__version__ = "1.7.2"
+__version__ = "1.7.3"
 
 from kriegspiel.berkeley import BerkeleyGame
 from kriegspiel.cincinnati import CincinnatiGame

--- a/kriegspiel/rulesets.py
+++ b/kriegspiel/rulesets.py
@@ -96,6 +96,7 @@ class BerkeleyRulesetPolicy:
         if self.release_ask_any_after_failed_pawn_try and game.must_use_pawns and answer.main_announcement == MA.ILLEGAL_MOVE:
             game._must_use_pawns = False
             game._generate_possible_to_ask_list()
+            game._discard_possible_to_ask(KSMove(QA.ASK_ANY))
             return
         if not self.allow_ask_any:
             return

--- a/kriegspiel/serialization.py
+++ b/kriegspiel/serialization.py
@@ -9,7 +9,7 @@ Kriegspiel game components using JSON format with custom encoders/decoders.
 JSON Schema Structure:
 {
   "schema_version": 9,
-  "library_version": "1.7.2",
+  "library_version": "1.7.3",
   "game_type": "BerkeleyGame",
   "game_state": {
     "ruleset_id": "berkeley_any",

--- a/tests/test_crazykrieg.py
+++ b/tests/test_crazykrieg.py
@@ -175,6 +175,8 @@ def test_crazykrieg_any_yes_requires_one_pawn_try_then_releases_after_failed_try
     assert game.ask_for(empty_pawn_try) == KSAnswer(MA.ILLEGAL_MOVE)
     assert game.must_use_pawns is False
     assert rook_move in game.possible_to_ask
+    assert KSMove(QA.ASK_ANY) not in game.possible_to_ask
+    assert game.ask_for(KSMove(QA.ASK_ANY)) == KSAnswer(MA.IMPOSSIBLE_TO_ASK)
 
 
 def test_crazykrieg_drop_can_give_check_without_revealing_square():

--- a/tests/test_english.py
+++ b/tests/test_english.py
@@ -80,8 +80,27 @@ def test_english_failed_pawn_try_releases_any_obligation():
     assert game.ask_for(empty_pawn_try) == KSAnswer(MA.ILLEGAL_MOVE)
     assert game.must_use_pawns is False
     assert rook_move in game.possible_to_ask
+    assert KSMove(QA.ASK_ANY) not in game.possible_to_ask
     assert empty_pawn_try not in game.possible_to_ask
+    assert game.ask_for(KSMove(QA.ASK_ANY)) == KSAnswer(MA.IMPOSSIBLE_TO_ASK)
     assert game.ask_for(rook_move) == KSAnswer(MA.CAPTURE_DONE, capture_at_square=chess.A5)
+
+
+def test_english_failed_pawn_try_keeps_any_unavailable_after_later_illegal_attempt():
+    game = EnglishGame()
+    ask_any = KSMove(QA.ASK_ANY)
+    failed_pawn_try = KSMove(QA.COMMON, chess.Move.from_uci("e4f5"))
+    illegal_knight_try = KSMove(QA.COMMON, chess.Move.from_uci("g1g3"))
+
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("e2e4"))) == KSAnswer(MA.REGULAR_MOVE)
+    assert game.ask_for(KSMove(QA.COMMON, chess.Move.from_uci("d7d5"))) == KSAnswer(MA.REGULAR_MOVE)
+    assert game.ask_for(ask_any) == KSAnswer(MA.HAS_ANY)
+    assert game.ask_for(failed_pawn_try) == KSAnswer(MA.ILLEGAL_MOVE)
+    assert game.ask_for(illegal_knight_try) == KSAnswer(MA.ILLEGAL_MOVE)
+
+    assert game.must_use_pawns is False
+    assert ask_any not in game.possible_to_ask
+    assert game.ask_for(ask_any) == KSAnswer(MA.IMPOSSIBLE_TO_ASK)
 
 
 def test_english_legal_pawn_capture_after_any_completes_move():


### PR DESCRIPTION
## Summary
- remove `ASK_ANY` from the same-ply prompt after English/CrazyKrieg releases a player from the required pawn try
- add English and CrazyKrieg regressions for repeated Any? attempts after a failed pawn try
- bump kriegspiel package version to 1.7.3 and document release notes

## Rationale
English rules allow one Any? question per ply. A positive answer requires one pawn-capture try; if that try is illegal, the player may make any legal move, but should not be able to ask Any? again in the same ply.

## Tests
- `PYTHONPATH=/home/codex/dev/kriegspiel/_worktrees/ks-game-english-any-once /home/codex/dev/kriegspiel/ks-game/.venv/bin/python -m pytest --no-cov tests/test_english.py tests/test_crazykrieg.py`
- `PYTHONPATH=/home/codex/dev/kriegspiel/_worktrees/ks-game-english-any-once /home/codex/dev/kriegspiel/ks-game/.venv/bin/python -m pytest`
- `PYTHONPATH=/home/codex/dev/kriegspiel/_worktrees/ks-game-english-any-once /home/codex/dev/kriegspiel/ks-game/.venv/bin/python -m build`
- `/home/codex/dev/kriegspiel/ks-game/.venv/bin/python -m twine check dist/*`

## Deployment Notes
- Publish `kriegspiel` 1.7.3 to PyPI after merge/tag.
- Update backend dependency pin to the released ks-game commit, then redeploy backend.